### PR TITLE
Added PolicyReference to SAML.xml

### DIFF
--- a/client/office365/runtime/auth/SAML.xml
+++ b/client/office365/runtime/auth/SAML.xml
@@ -19,6 +19,7 @@
           <a:Address>[endpoint]</a:Address>
         </a:EndpointReference>
       </wsp:AppliesTo>
+      <wsp:PolicyReference xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" URI="MBI"></wsp:PolicyReference>
       <t:KeyType>http://schemas.xmlsoap.org/ws/2005/05/identity/NoProofKey</t:KeyType>
       <t:RequestType>http://schemas.xmlsoap.org/ws/2005/02/trust/Issue</t:RequestType>
       <t:TokenType>urn:oasis:names:tc:SAML:1.0:assertion</t:TokenType>


### PR DESCRIPTION
This forces sts service to return BinarySecurityToken in plain text instead of  encrypted xml data.
Some of Office365 tenants return the security token in encrypted xml data. That causes saml_token_provider.process_service_token_response  method to fail.

The same problem is described for example here:
http://stackoverflow.com/questions/9626539/saml-token-format
