### PR TITLE
Packaging for PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.md

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ The list of supported Office 365 REST APIs:
 
 # Installation
 
-Todo
+Use pip:
+
+```
+pip install Office365-REST-Python-Client
+```
 
 
 # Usage: working with SharePoint resources 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+description-file = README.md
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+from distutils.core import setup
+import setuptools
+
+def read(fname):
+    """From an_example_pypi_project (https://pypi.python.org/pypi/an_example_pypi_project). """
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+setup(
+    name="Office365-REST-Python-Client",
+    version="1.0.0"
+    author="Vadim Gremyachev",
+    author_email="vvgrem@gmail.com",
+    maintainer="Konrad Gądek",
+    maintainer_email="kgadek@gmail.com",
+    description="Office 365 REST client for Python",
+    long_description=read("README.md"),
+    url="https://github.com/vgrem/Office365-REST-Python-Client",
+    install_requires=['requests'],
+    license="MIT",
+    keywords="git",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Topic :: Internet :: WWW/HTTP",
+        "Topic :: Software Development :: Libraries"
+    ],
+    packages=setuptools.find_packages()
+)
+


### PR DESCRIPTION
Adds required metadata for the project. Closes #10.

With these changes, creating package is performed by:

    python setup.py sdist

To upload a package, first refer to the docs [[1]]. After initial setup:

    twine upload dist/*

[1]: https://packaging.python.org/distributing/#uploading-your-project-to-pypi


There were some choices (describe below) that I took to make this PR. Of course I'd be happy to discuss and change those before merging.

I've set up the version to `1.0.0`, however classified package as Beta. I've assumed this package is quite stable but not super-stable yet. That would mean beta. Having this in mind, version `0.x.x` would make more sense. However, I dislike the exception in the SemVer [[2]] that allows arbitrary breakage:

[2]: http://semver.org/#semantic-versioning-specification-semver

> Major version zero (0.y.z) is for initial development. Anything may change at any time. The public API should not be considered stable.

Another thing is: who shall upload this to PyPI? I volunteer to do that. Therefore, I've added myself as maintainer of the package. Having said that, the process of creating PyPI package is straightforward and quite quick, so if you would rather do it yourself, I'll just update the maintainer field.

There are some classifiers that I've selected from the list [[3]].

[3]: https://pypi.python.org/pypi?%3Aaction=list_classifiers