### PR TITLE
Packaging for PyPI — silly error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name="Office365-REST-Python-Client",
-    version="1.0.0"
+    version="1.0.0",
     author="Vadim Gremyachev",
     author_email="vvgrem@gmail.com",
     maintainer="Konrad Gądek",


### PR DESCRIPTION
Typo. I've accidentally removed a comma during final touches.