### PR TITLE
nosetests: disable defunct test

### DIFF
--- a/tests/test_listItem.py
+++ b/tests/test_listItem.py
@@ -1,5 +1,6 @@
 from random import randint
 from tests.sharepoint_case import SPTestCase
+from nose.tools import nottest
 
 
 class TestListItem(SPTestCase):
@@ -8,6 +9,7 @@ class TestListItem(SPTestCase):
     def setUp(self):
         self.target_list = self.context.web.lists.get_by_title("Tasks")
 
+    @nottest
     def test_create_list_item(self):
         item_properties = {'Title': 'New Task', '__metadata': {'type': 'SP.Data.TasksListItem'}}
         item = self.target_list.add_item(item_properties)


### PR DESCRIPTION
The global state changed and the resource is not available anymore. This
causes one of the test cases to fail, even for code that once passed all
tests successfully (tested on 7dc8de9c20f306085139cc867e9ba10dbf4436a1).

This is not a perfect solution, though I don't feel I should hop into server, check what's there, etc.

Closes #17.