### PR TITLE
Logging in client.office365.runtime.auth.saml_token_provider.py

### DIFF
--- a/client/office365/logger.py
+++ b/client/office365/logger.py
@@ -1,0 +1,29 @@
+import logging
+
+LOGGING_SECRET_LVL = 5
+LOGGING_SECRET_NAME = "SECDEBUG"
+
+
+def ensure_debug_secrets():
+    """Idempotent: add debug_secrets to Python's logging.Logger class."""
+    if 'debug_secrets' not in logging.Logger.__dict__:
+        def _log_secrets(self, *args, **kwargs):
+            self.log(LOGGING_SECRET_LVL, *args, **kwargs)
+
+        logging.Logger.debug_secrets = _log_secrets
+
+
+# noinspection PyClassHasNoInit
+class LoggableClass:
+    """Superclass for all classes that require namespaced logger."""
+    _logger = None
+
+    @classmethod
+    def logger(cls, method=None):
+        if cls._logger is None:
+            logger_name = cls.__module__ + '.' + cls.__name__
+            cls._logger = logging.getLogger(logger_name)
+
+        if method is not None:
+            return cls._logger.getChild(method)
+        return cls._logger

--- a/client/office365/runtime/auth/saml_token_provider.py
+++ b/client/office365/runtime/auth/saml_token_provider.py
@@ -3,10 +3,14 @@ import urlparse
 from xml.etree import ElementTree
 import requests
 import requests.utils
+
 from client.office365.runtime.auth.base_token_provider import BaseTokenProvider
+import client.office365.logger
+
+client.office365.logger.ensure_debug_secrets()
 
 
-class SamlTokenProvider(BaseTokenProvider):
+class SamlTokenProvider(BaseTokenProvider, client.office365.logger.LoggableClass):
     """ SAML Security Token Service for O365"""
 
     def __init__(self, url, username, password):
@@ -33,7 +37,11 @@ class SamlTokenProvider(BaseTokenProvider):
 
     def acquire_token(self):
         """Acquire user token"""
+        logger = self.logger(self.acquire_token.__name__)
+        logger.debug('called')
+
         try:
+            logger.debug("Parsing URL")
             url = urlparse.urlparse(self.url)
             options = {
                 'username': self.username,
@@ -51,6 +59,9 @@ class SamlTokenProvider(BaseTokenProvider):
 
     def get_authentication_cookie(self):
         """Generate Auth Cookie"""
+        logger = self.logger(self.get_authentication_cookie.__name__)
+
+        logger.debug_secrets("self.FedAuth: %s\nself.rtFa: %s", self.FedAuth, self.rtFa)
         return 'FedAuth=' + self.FedAuth + '; rtFa=' + self.rtFa
 
     def get_last_error(self):
@@ -58,6 +69,9 @@ class SamlTokenProvider(BaseTokenProvider):
 
     def acquire_service_token(self, options):
         """Retrieve service token"""
+        logger = self.logger(self.acquire_service_token.__name__)
+        logger.debug_secrets('options: %s', options)
+
         request_body = self.prepare_security_token_request({
             'username': options['username'],
             'password': options['password'],
@@ -67,48 +81,64 @@ class SamlTokenProvider(BaseTokenProvider):
         sts_url = 'https://' + options['sts']['host'] + options['sts']['path']
         response = requests.post(sts_url, data=request_body)
         token = self.process_service_token_response(response)
+        logger.debug_secrets('token: %s', token)
         if token:
             self.token = token
             return True
         return False
 
     def process_service_token_response(self, response):
+        logger = self.logger(self.process_service_token_response.__name__)
+        logger.debug_secrets('response: %s\nresponse.content: %s', response, response.content)
+
         xml = ElementTree.fromstring(response.content)
         ns_prefixes = {'S': '{http://www.w3.org/2003/05/soap-envelope}',
                        'psf': '{http://schemas.microsoft.com/Passport/SoapServices/SOAPFault}',
                        'wst': '{http://schemas.xmlsoap.org/ws/2005/02/trust}',
                        'wsse': '{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}'}
+        logger.debug_secrets("ns_prefixes: %s", ns_prefixes)
 
         # check for errors
         if xml.find('{0}Body/{0}Fault'.format(ns_prefixes['S'])) is not None:
             error = xml.find('{0}Body/{0}Fault/{0}Detail/{1}error/{1}internalerror/{1}text'.format(ns_prefixes['S'],
                                                                                                    ns_prefixes['psf']))
             self.error = 'An error occurred while retrieving token: {0}'.format(error.text)
+            logger.error(self.error)
             return None
 
         # extract token
         token = xml.find(
             '{0}Body/{1}RequestSecurityTokenResponse/{1}RequestedSecurityToken/{2}BinarySecurityToken'.format(
                 ns_prefixes['S'], ns_prefixes['wst'], ns_prefixes['wsse']))
+        logger.debug_secrets("token: %s", token)
         return token.text
 
     def acquire_authentication_cookie(self, options):
         """Retrieve SPO auth cookie"""
+        logger = self.logger(self.acquire_authentication_cookie.__name__)
+
         url = options['endpoint']
 
         session = requests.session()
+        logger.debug_secrets("session: %s\nsession.post(%s, data=%s)", session, url, self.token)
         session.post(url, data=self.token)
+        logger.debug_secrets("session.cookies: %s", session.cookies)
         cookies = requests.utils.dict_from_cookiejar(session.cookies)
+        logger.debug_secrets("cookies: %s", cookies)
         if 'FedAuth' in cookies and 'rtFa' in cookies:
             self.FedAuth = cookies['FedAuth']
             self.rtFa = cookies['rtFa']
             return True
         self.error = "An error occurred while retrieving auth cookies"
+        logger.error(self.error)
         return False
 
     @staticmethod
     def prepare_security_token_request(params):
         """Construct the request body to acquire security token from STS endpoint"""
+        logger = SamlTokenProvider.logger(SamlTokenProvider.prepare_security_token_request.__name__)
+        logger.debug_secrets('params: %s', params)
+
         f = open(os.path.join(os.path.dirname(__file__), 'SAML.xml'))
         data = f.read()
         for key in params:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name="Office365-REST-Python-Client",
-    version="1.0.1",
+    version="1.1.0",
     author="Vadim Gremyachev",
     author_email="vvgrem@gmail.com",
     maintainer="Konrad Gądek",


### PR DESCRIPTION
Logging in saml_token_provider

This PR also introduces `LOGGING_SECRET_LVL`, a logging level below `DEBUG`. Both internal modules and library consumers may use this new level after running initialization method - it registers aforementioned level and `logging.Logger.debug_secrets()` method.

```python
import client.office365.logger
client.office365.logger.ensure_debug_secrets()
```

The discussion on the design choices: https://github.com/vgrem/Office365-REST-Python-Client/issues/22