### PR TITLE
Refactor execute_query to execute_request

### DIFF
--- a/examples/listitems_operations_alt.py
+++ b/examples/listitems_operations_alt.py
@@ -9,7 +9,7 @@ def read_list_items(web_url, ctx_auth, list_title):
     request_url = "{0}/_api/web/lists/getbyTitle('{1}')/items".format(web_url, list_title)  # Web resource endpoint
 
     print("Retrieving list items from List {0}".format(list_title))
-    data = request.execute_query_direct(request_url=request_url)
+    data = request.execute_request_direct(request_url=request_url)
     for item in data['d']['results']:
         print("Item title: {0}".format(item["Title"]))
 
@@ -21,7 +21,7 @@ def create_list_item(web_url, ctx_auth, list_title):
 
     print("Creating list item...")
     item_payload = {'__metadata': {'type': 'SP.Data.TasksListItem'}, 'Title': 'New Task'}
-    data = request.execute_query_direct(request_url=request_url, data=item_payload)
+    data = request.execute_request_direct(request_url=request_url, data=item_payload)
     print("Task {0} has been successfully [created]".format(data['d']['Title']))
     return data['d']
 
@@ -36,7 +36,7 @@ def update_list_item(web_url, ctx_auth, list_title, item_id):
         'IF-MATCH': '*',
         'X-HTTP-Method': 'MERGE'
     }
-    request.execute_query_direct(request_url=request_url, headers=headers, data=item_payload)
+    request.execute_request_direct(request_url=request_url, headers=headers, data=item_payload)
     print("Task has been successfully [updated]")
 
 
@@ -49,7 +49,7 @@ def delete_list_item(web_url, ctx_auth, list_title, item_id):
         'IF-MATCH': '*',
         'X-HTTP-Method': 'DELETE'
     }
-    request.execute_query_direct(request_url=request_url, headers=headers)
+    request.execute_request_direct(request_url=request_url, headers=headers)
     print("Task has been successfully [deleted]")
 
 

--- a/examples/web_read_direct.py
+++ b/examples/web_read_direct.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
         options = RequestOptions("{0}/_api/web/".format(settings['url']))
         options.set_header('Accept', 'application/json')
         options.set_header('Content-Type', 'application/json')
-        data = ctx.execute_query_direct(options)
+        data = ctx.execute_request_direct(options)
         s = json.loads(data.content)
         web_title = s['Title']
         print("Web title: {0}".format(web_title))

--- a/office365/runtime/client_query.py
+++ b/office365/runtime/client_query.py
@@ -52,6 +52,10 @@ class ClientQuery(object):
     def id(self):
         return id(self)
 
+    def execute(self, context, client_object=None):
+        from office365.runtime.client_request import ClientRequest
+        return ClientRequest(context).execute_single_query(self, client_object)
+
     def __hash__(self):
         return hash(self.url)
 

--- a/office365/runtime/client_runtime_context.py
+++ b/office365/runtime/client_runtime_context.py
@@ -26,8 +26,8 @@ class ClientRuntimeContext(object):
         qry = ClientQuery(client_object.url, ActionType.ReadEntry)
         self.pending_request.add_query(qry, client_object)
 
-    def execute_query_direct(self, request):
-        return self.pending_request.execute_query_direct(request)
+    def execute_request_direct(self, request):
+        return self.pending_request.execute_request_direct(request)
 
     def execute_query(self):
         self.pending_request.execute_query()

--- a/office365/sharepoint/file.py
+++ b/office365/sharepoint/file.py
@@ -46,7 +46,7 @@ class File(AbstractFile):
         request.method = HttpMethod.Post
         request.set_header('X-HTTP-Method', 'PUT')
         request.data = content
-        response = ctx.execute_query_direct(request)
+        response = ctx.execute_request_direct(request)
         return response
 
     @staticmethod
@@ -59,7 +59,7 @@ class File(AbstractFile):
         url = "{0}web/getfilebyserverrelativeurl('{1}')/\$value".format(ctx.service_root_url, server_relative_url)
         request = RequestOptions(url)
         request.method = HttpMethod.Get
-        response = ctx.execute_query_direct(request)
+        response = ctx.execute_request_direct(request)
         return response
 
     @staticmethod
@@ -72,7 +72,7 @@ class File(AbstractFile):
         url = "{0}web/getfilebyserverrelativeurl('{1}')/\$value".format(ctx.service_root_url, server_relative_url)
         request = RequestOptions(url)
         request.method = HttpMethod.Delete
-        response = ctx.execute_query_direct(request)
+        response = ctx.execute_request_direct(request)
         return response
 
     @property


### PR DESCRIPTION
This is to avoid confusion between ClientQuery and ClientRequest objects.

It also add a execute() method on query objects to execute queries from ClientQuery without having to build a ClientRequest manually (those objects are easier to understand).