### PR TITLE
TravisCI deployments to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,26 @@ matrix:
 
 # command to run tests
 script: python setup.py test
+
+stages:
+  # Tests are configured in upstream
+  - name: test
+    if: repo = "vgrem/Office365-REST-Python-Client"
+  # Deploy is currently configured in maintainer's fork
+  - name: deploy
+    if: repo = "kgadek/Office365-REST-Python-Client" AND tag IS present
+
+jobs:
+  include:
+    - stage: deploy
+      python: 3.6
+      script: true
+      deploy:
+        provider: pypi
+        user: kgadek
+        skip_existing: true
+        password:
+          secure: yEUHdUuAIVyU5UNtUo+9SVnQ//0E732eyb/yurA+dEx5M2THohzdX6T8jt+4xj4y0brtfSY1xOfNX4OW+yDXjsEZfOL7GZQSEkF+6LLRcO4gEJNYPXxDNe/N0/G1gN/w5d5jhzw6JUJaLsTzk5tmx51JYI6wMEHjYdM5948Mbja7Ya6h6wTIq0bmIu54OMUdcwdSXEFj3s3ZnxT8Qc57WS8Tg/ax1fL8JuPJNvOVe3qW9+NbFL01vosymLWqwOyhMkJp8J06nNtL3ijpZ/4uxITjRbKKRhcuMbBuTF5aV4FzONlxh+7lJ7ZvLWliB6HvYlJL1fQWj3ff/mxu8sa9YNeytGGfrZFeV/6AcqcJQnTj80vfwVKseL1Y4hqGMQey7kRGwUN1PjwaSQcAsqWcSDvgvb+LH4+c+Ha/LqM3ysQckR9FRFLarnX9wOhIUiLA3M9iEK7exCeOXstmJv3mGb774BetmrVT/Sp58SC8TVmbs/NbqukOkoUfTIwsOhNNSZPmpm/c6xjDXcVqdawAr4t6pjpy7q6yu9nuKJ7/V8A57Vm7o53O4CNwhkywPT9PVnDfzazj2a3Ech8BZ34nKugsz1o5r8fVRrdfbtcNR+NN3/TuuYYTLmM4JMkngc8XJNxubnHt53oCxyLsbuCr8VqlGTVQ+AH+2HpDZQ3be5I=
+        on:
+          tags: true
+

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,8 @@ import os
 from distutils.core import setup
 import setuptools
 
-def read(fname):
-    """From an_example_pypi_project (https://pypi.python.org/pypi/an_example_pypi_project). """
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+with open("README.md", "r") as fh:
+    long_description = fh.read()
 
 setup(
     name="Office365-REST-Python-Client",
@@ -17,7 +16,7 @@ setup(
     maintainer="Konrad Gądek",
     maintainer_email="kgadek@gmail.com",
     description="Office 365 REST client for Python",
-    long_description=read("README.md"),
+    long_description=long_description,
     url="https://github.com/vgrem/Office365-REST-Python-Client",
     install_requires=['requests'],
     tests_require=['nose'],


### PR DESCRIPTION
Implements deployment stage: will upload package automatically to PyPI:
https://pypi.python.org/pypi/Office365-REST-Python-Client .

Due to security measures, the deployment is currently possible only from
this fork: https://github.com/kgadek/Office365-REST-Python-Client .

Closes #92
Ref https://github.com/vgrem/Office365-REST-Python-Client/issues/75
Ref https://github.com/vgrem/Office365-REST-Python-Client/issues/77