### PR TITLE
PyPI fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="Office365-REST-Python-Client",
-    version="2.1.1",
+    version="2.1.2",
     author="Vadim Gremyachev",
     author_email="vvgrem@gmail.com",
     maintainer="Konrad Gądek",

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     maintainer_email="kgadek@gmail.com",
     description="Office 365 REST client for Python",
     long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/vgrem/Office365-REST-Python-Client",
     install_requires=['requests'],
     tests_require=['nose'],


### PR DESCRIPTION
This was used to deploy v2.1.2 into PyPI (see #102):

* version bump was needed in `setup.py`,
* had to add `long_description_content_type="text/markdown"`.