### PR TITLE
Added Sharepoint "MoveTo" REST API method to File.py 

### DIFF
--- a/office365/sharepoint/file.py
+++ b/office365/sharepoint/file.py
@@ -74,6 +74,20 @@ class File(AbstractFile):
         request.method = HttpMethod.Delete
         response = ctx.execute_request_direct(request)
         return response
+    
+    @staticmethod
+    def moveto_binary(ctx, server_relative_url, new_relative_url):
+        try:
+            from urllib import quote  # Python 2.X
+        except ImportError:
+            from urllib.parse import quote  # Python 3+
+        server_relative_url = quote(server_relative_url)
+        new_relative_url = quote(new_relative_url)
+        url = "{0}/web/getfilebyserverrelativeurl('{1}')/\moveto(newurl='{2}', flags=1)".format(ctx.service_root_url, server_relative_url, new_relative_url)
+        request = RequestOptions(url)
+        request.method = HttpMethod.Post
+        response = ctx.execute_request_direct(request)
+        return response
 
     @property
     def listitem_allfields(self):


### PR DESCRIPTION
By referring to this post : https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-rest-reference/dn450841%28v%3doffice.15%29#moveto-method

Recently i am developing python automation script for my project and I found missing "MoveTo" method in this beautiful Office365-REST-Python-Client project. So, i decided to add the this ```MoveTo``` method in the File Class.  

Please review and merge it to the master.
