### PR TITLE
Add NTLM authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,15 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
 # C extensions
 *.so
 

--- a/office365/runtime/auth/ntlm_authentication_context.py
+++ b/office365/runtime/auth/ntlm_authentication_context.py
@@ -1,0 +1,17 @@
+from office365.runtime.auth.network_credential_context import NetworkCredentialContext
+
+try:
+    from requests_ntlm import HttpNtlmAuth
+except ImportError:
+    raise ImportError("To use NTLM authentication the package 'requests_ntlm' needs to be installed")
+
+
+class NTLMAuthenticationContext(NetworkCredentialContext):
+    """Provides NTLM authentication"""
+
+    def __init__(self, username, password):
+        super(NTLMAuthenticationContext, self).__init__(username, password)
+        self.auth = HttpNtlmAuth(*self.userCredentials)
+
+    def authenticate_request(self, request_options):
+        request_options.auth = self.auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+requests_ntlm [NTLMAuthentication]
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/vgrem/Office365-REST-Python-Client",
     install_requires=['requests'],
+    extras_require={
+        'NTLMAuthentication': ["requests_ntlm"],
+    },
     tests_require=['nose'],
     test_suite='nose.collector',
     license="MIT",


### PR DESCRIPTION
Add NTLM authentication that is used in some SharePoint setups. The extra dependencies needed to use NTLM authentication is marked as optional and must be installed explicitly `pip install requests_ntlm` . 

To use this authentication context:

```python
from office365.runtime.auth.ntlm_authentication_context import NTLMAuthenticationContext

auth_context = NTLMAuthenticationContext(username, password)
context = ClientContext(url, auth_context)
```