### PR TITLE
Get all list items #79

### DIFF
--- a/office365/runtime/client_object_collection.py
+++ b/office365/runtime/client_object_collection.py
@@ -50,9 +50,10 @@ class ClientObjectCollection(ClientObject):
         return len(self.__data)
 
     def __getitem__(self, index):
-        if self.__next_query_url:
-            # resolve all items first
-            list(iter(self))
+        # fetch only as much items as necessary
+        item_iterator = iter(self)
+        while len(self.__data) <= index and self.__next_query_url:
+            next(item_iterator)
 
         return self.__data[index]
 

--- a/office365/runtime/client_object_collection.py
+++ b/office365/runtime/client_object_collection.py
@@ -1,4 +1,5 @@
 from office365.runtime.client_object import ClientObject
+from office365.runtime.utilities.request_options import RequestOptions
 
 
 class ClientObjectCollection(ClientObject):
@@ -7,23 +8,52 @@ class ClientObjectCollection(ClientObject):
     def __init__(self, context, resource_path=None):
         super(ClientObjectCollection, self).__init__(context, resource_path)
         self.__data = []
+        self.__next_query_url = None
 
     def map_json(self, payload):
-        for properties in payload:
+        for properties in payload["collection"]:
             child_client_object = self.create_typed_object(properties)
             self.add_child(child_client_object)
+        self.__next_query_url = payload["next"]
 
     def add_child(self, client_object):
         client_object._parent_collection = self
         self.__data.append(client_object)
 
     def __iter__(self):
-        return iter(self.__data)
+        for _object in self.__data:
+            yield _object
+        while self.__next_query_url:
+            # create a request with the __next_query_url
+            request = RequestOptions(self.__next_query_url)
+            request.set_headers(self.context.json_format.build_http_headers())
+            response = self.context.execute_request_direct(request)
+            
+            # process the response
+            payload = self.context.pending_request.process_response_json(response)
+            self.__next_query_url = payload["next"]
+            child_client_objects = []
+            # add the new objects to the collection before yielding the results
+            for properties in payload["collection"]:
+                child_client_object = self.create_typed_object(properties)
+                self.add_child(child_client_object)
+                child_client_objects.append(child_client_object)
+
+            for child_client_object in child_client_objects:
+                yield child_client_object
 
     def __len__(self):
+        if self.__next_query_url:
+            # resolve all items first
+            list(iter(self))
+
         return len(self.__data)
 
     def __getitem__(self, index):
+        if self.__next_query_url:
+            # resolve all items first
+            list(iter(self))
+
         return self.__data[index]
 
     def filter(self, value):

--- a/office365/runtime/client_request.py
+++ b/office365/runtime/client_request.py
@@ -17,10 +17,6 @@ class ClientRequest(object):
         self.__queries = []
         self.__resultObjects = {}
 
-    def __int__(self, url, ctx_auth):
-        from office365.sharepoint.client_context import ClientContext
-        self.context = ClientContext(url, ctx_auth)
-
     def clear(self):
         self.__queries = []
         self.__resultObjects = {}

--- a/office365/runtime/odata/json_light_format.py
+++ b/office365/runtime/odata/json_light_format.py
@@ -10,6 +10,7 @@ class JsonLightFormat(ODataJsonFormat):
         if self.metadata == ODataMetadataLevel.Verbose:
             self.payload_root_entry = "d"
             self.payload_root_entry_collection = "results"
+            self.payload_root_entry_collection_next = "__next"
         else:
             self.payload_root_entry_collection = "value"
 

--- a/office365/runtime/odata/odata_json_format.py
+++ b/office365/runtime/odata/odata_json_format.py
@@ -8,6 +8,7 @@ class ODataJsonFormat(object):
         self.metadata = metadata
         self.payload_root_entry = None
         self.payload_root_entry_collection = None
+        self.payload_root_entry_collection_next = None
 
     __metaclass__ = ABCMeta
 


### PR DESCRIPTION
As stated in issue #79 only a limited number of items (default 100) will be resolved. This limit can be controlled with `top` so for example `ctx.web.lists.get_by_title("MyList").get_items().top(5)` will fetch only the first 5 results. To get all other results the query url `d.__next` contained in the response must be queried. This pull request does exactly that. When for example a `ListItemCollection` is created only the first items (count controlled by `top`) will be fetched. All other items will be fetched in a lazy fashion once they needed and added to the collection.