### PR TITLE
Resource path quirks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig helps maintain consistent coding styles for multiple developers
+# working on the same project across various editors and IDEs.
+# Read more: https://editorconfig.org/
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_size = 2
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,13 @@
+[MESSAGES CONTROL]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once).
+# all codes: http://pylint-messages.wikidot.com/all-codes
+disable=C0103, C0303

--- a/.pylintrc
+++ b/.pylintrc
@@ -11,3 +11,5 @@
 # it should appear only once).
 # all codes: http://pylint-messages.wikidot.com/all-codes
 disable=C0103, C0303
+
+max-line-length=120

--- a/.pylintrc
+++ b/.pylintrc
@@ -10,6 +10,6 @@
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
 # all codes: http://pylint-messages.wikidot.com/all-codes
-disable=C0103, C0303
+disable=C0103, C0303, C0111
 
 max-line-length=120

--- a/office365/outlookservices/attachment_collection.py
+++ b/office365/outlookservices/attachment_collection.py
@@ -1,5 +1,9 @@
 from office365.runtime.client_object_collection import ClientObjectCollection
+from office365.outlookservices.attachment import Attachment
 
 
 class AttachmentCollection(ClientObjectCollection):
     """Attachment collection"""
+
+    # The object type this collection holds
+    item_type = Attachment

--- a/office365/outlookservices/contact_collection.py
+++ b/office365/outlookservices/contact_collection.py
@@ -7,6 +7,9 @@ from office365.runtime.resource_path_entry import ResourcePathEntry
 class ContactCollection(ClientObjectCollection):
     """User's contact collection"""
 
+    # The object type this collection holds
+    item_type = Contact
+
     def add_from_json(self, contact_creation_information):
         """Creates a Contact resource from JSON"""
         contact = Contact(self.context)

--- a/office365/outlookservices/event_collection.py
+++ b/office365/outlookservices/event_collection.py
@@ -5,6 +5,10 @@ from office365.runtime.client_query import ClientQuery
 
 class EventCollection(ClientObjectCollection):
     """Event's collection"""
+
+    # The object type this collection holds
+    item_type = Event
+
     def add_from_json(self, event_creation_information):
         """Creates a Event resource from JSON"""
         event = Event(self.context)

--- a/office365/outlookservices/message_collection.py
+++ b/office365/outlookservices/message_collection.py
@@ -1,5 +1,9 @@
+from office365.outlookservices.message import Message
 from office365.runtime.client_object_collection import ClientObjectCollection
 
 
 class MessageCollection(ClientObjectCollection):
     """Message's collection"""
+
+    # The object type this collection holds
+    item_type = Message

--- a/office365/outlookservices/outlook_entity.py
+++ b/office365/outlookservices/outlook_entity.py
@@ -17,10 +17,15 @@ class OutlookEntity(ClientObject):
 
     @property
     def resource_path(self):
-        orig_path = ClientObject.resource_path.fget(self)
-        if self.is_property_available("Id") and orig_path is None:
-            return ResourcePathEntry(self.context,
-                                     self._parent_collection.resource_path,
-                                     self.properties["Id"])
-        return orig_path
+        resource_path = super(OutlookEntity, self).resource_path
+        if resource_path:
+            return resource_path
 
+        # fallback: create a new resource path
+        if self.is_property_available("Id"):
+            return ResourcePathEntry(
+                self.context,
+                self._parent_collection.resource_path,
+                self.properties["Id"])
+
+        return self._resource_path

--- a/office365/runtime/client_object.py
+++ b/office365/runtime/client_object.py
@@ -1,6 +1,8 @@
 import importlib
+from urllib3.util import parse_url
 
 from office365.runtime.odata.odata_metadata_level import ODataMetadataLevel
+from office365.runtime.resource_path_entry import ResourcePathEntry
 
 
 class ClientObject(object):
@@ -49,22 +51,34 @@ class ClientObject(object):
         if '__metadata' not in entity:
             entity["__metadata"] = {'type': self.entity_type_name}
 
-    def create_typed_object(self, properties):
-        entity_name = self.__class__.__name__.replace("Collection", "")
+    def create_typed_object(self, properties, client_object_type=None):
         from office365.sharepoint.client_context import ClientContext
-        if isinstance(self.context, ClientContext):
-            module_name = self.context.__module__.replace("client_context", "") + entity_name.lower()
-        else:
-            module_name = self.context.__module__.replace("outlook_client", "") + entity_name.lower()
-        client_object_type = getattr(importlib.import_module(module_name), entity_name)
+
+        if client_object_type is None:
+            # get type from metadata; the form is 'SP.ObjectType'
+            client_object_type_name = properties["__metadata"]["type"][3:]
+
+            if isinstance(self.context, ClientContext):
+                module_name = self.context.__module__.replace("client_context", "") + client_object_type_name.lower()
+            else:
+                module_name = self.context.__module__.replace("outlook_client", "") + client_object_type_name.lower()
+
+            try:
+                lib = importlib.import_module(module_name)
+                client_object_type = getattr(lib, client_object_type_name)
+            except ModuleNotFoundError:
+                raise ModuleNotFoundError("No class for object type '{0}' found".format(client_object_type_name))
+
+        web_url, resource_path = properties["__metadata"]["uri"].split("/_api/")
+
         context = self.context
-        if entity_name == "Web":
+        if client_object_type.__name__ == "Web":
             # create a new context to represent the new web object
-            web_url = properties["__metadata"]["uri"]
-            web_url = web_url[:web_url.rfind("/_api")]
             context = ClientContext(web_url, self.context.auth_context)
-        client_object = client_object_type(context)
+
+        client_object = client_object_type(context, ResourcePathEntry.from_uri(resource_path, self.context))
         client_object.map_json(properties)
+
         return client_object
 
     def remove_from_parent_collection(self):
@@ -98,6 +112,14 @@ class ClientObject(object):
 
     @property
     def resource_path(self):
+        if self._resource_path:
+            return self._resource_path
+
+        url_parsed = parse_url(self._metadata.get("uri", ""))
+        if url_parsed.path:
+            self._resource_path = ResourcePathEntry.from_uri(
+                url_parsed.path[url_parsed.path.rfind("/_api/")+6:], self._context)
+
         return self._resource_path
 
     @property

--- a/office365/runtime/client_object_collection.py
+++ b/office365/runtime/client_object_collection.py
@@ -31,14 +31,14 @@ class ClientObjectCollection(ClientObject):
             request = RequestOptions(self.__next_query_url)
             request.set_headers(self.context.json_format.build_http_headers())
             response = self.context.execute_request_direct(request)
-            
+
             # process the response
             payload = self.context.pending_request.process_response_json(response)
             self.__next_query_url = payload["next"]
             child_client_objects = []
             # add the new objects to the collection before yielding the results
             for properties in payload["collection"]:
-                child_client_object = self.create_typed_object(properties)
+                child_client_object = self.create_typed_object(properties, self.item_type)
                 self.add_child(child_client_object)
                 child_client_objects.append(child_client_object)
 

--- a/office365/runtime/client_object_collection.py
+++ b/office365/runtime/client_object_collection.py
@@ -5,6 +5,9 @@ from office365.runtime.utilities.request_options import RequestOptions
 class ClientObjectCollection(ClientObject):
     """Client object collection"""
 
+    # The object type this collection holds
+    item_type = ClientObject
+
     def __init__(self, context, resource_path=None):
         super(ClientObjectCollection, self).__init__(context, resource_path)
         self.__data = []
@@ -12,7 +15,7 @@ class ClientObjectCollection(ClientObject):
 
     def map_json(self, payload):
         for properties in payload["collection"]:
-            child_client_object = self.create_typed_object(properties)
+            child_client_object = self.create_typed_object(properties, self.item_type)
             self.add_child(child_client_object)
         self.__next_query_url = payload["next"]
 

--- a/office365/runtime/resource_path_entry.py
+++ b/office365/runtime/resource_path_entry.py
@@ -23,5 +23,3 @@ class ResourcePathEntry(ResourcePath):
         for element in elements:
             parent = ResourcePathEntry(context, parent, element)
         return parent
-
-

--- a/office365/sharepoint/attachmentfile_collection.py
+++ b/office365/sharepoint/attachmentfile_collection.py
@@ -10,6 +10,9 @@ from office365.sharepoint.file import File
 class AttachmentfileCollection(ClientObjectCollection):
     """Represents a collection of AttachmentFile resources."""
 
+    # The object type this collection holds
+    item_type = Attachmentfile
+
     def add(self, attachment_file_information):
         """Creates an attachment"""
         if isinstance(attachment_file_information, dict):

--- a/office365/sharepoint/content_type_collection.py
+++ b/office365/sharepoint/content_type_collection.py
@@ -1,5 +1,8 @@
 from office365.runtime.client_object_collection import ClientObjectCollection
-
+from office365.sharepoint.content_type import ContentType
 
 class ContentTypeCollection(ClientObjectCollection):
     """Content Type resource collection"""
+
+    # The object type this collection holds
+    item_type = ContentType

--- a/office365/sharepoint/file_collection.py
+++ b/office365/sharepoint/file_collection.py
@@ -8,6 +8,9 @@ from office365.sharepoint.file import File
 class FileCollection(ClientObjectCollection):
     """Represents a collection of File resources."""
 
+    # The object type this collection holds
+    item_type = File
+
     def add(self, file_creation_information):
         """Creates a File resource"""
         file_new = File(self.context)

--- a/office365/sharepoint/folder_collection.py
+++ b/office365/sharepoint/folder_collection.py
@@ -2,13 +2,16 @@ from office365.runtime.action_type import ActionType
 from office365.runtime.client_object_collection import ClientObjectCollection
 from office365.runtime.client_query import ClientQuery
 from office365.runtime.resource_path_service_operation import ResourcePathServiceOperation
+from office365.sharepoint.folder import Folder
 
 
 class FolderCollection(ClientObjectCollection):
     """Represents a collection of Folder resources."""
 
+    # The object type this collection holds
+    item_type = Folder
+
     def add(self, folder_url):
-        from office365.sharepoint.folder import Folder
         folder = Folder(self.context)
         folder.set_property("ServerRelativeUrl", folder_url)
         qry = ClientQuery(self.url, ActionType.CreateEntry, folder.convert_to_payload())
@@ -17,5 +20,4 @@ class FolderCollection(ClientObjectCollection):
 
     def get_by_url(self, url):
         """Retrieve Folder resource by url"""
-        from office365.sharepoint.folder import Folder
         return Folder(self.context, ResourcePathServiceOperation(self.context, self.resource_path, "GetByUrl", [url]))

--- a/office365/sharepoint/group_collection.py
+++ b/office365/sharepoint/group_collection.py
@@ -8,6 +8,9 @@ from office365.sharepoint.group import Group
 class GroupCollection(ClientObjectCollection):
     """Represents a collection of Group resources."""
 
+    # The object type this collection holds
+    item_type = Group
+
     def add(self, group_creation_information):
         """Creates a Group resource"""
         group = Group(self.context)

--- a/office365/sharepoint/listItem_collection.py
+++ b/office365/sharepoint/listItem_collection.py
@@ -1,5 +1,9 @@
 from office365.runtime.client_object_collection import ClientObjectCollection
+from office365.sharepoint.listitem import ListItem
 
 
 class ListItemCollection(ClientObjectCollection):
     """List Item collection"""
+
+    # The object type this collection holds
+    item_type = ListItem

--- a/office365/sharepoint/list_collection.py
+++ b/office365/sharepoint/list_collection.py
@@ -8,6 +8,9 @@ from office365.sharepoint.list import List
 class ListCollection(ClientObjectCollection):
     """Lists collection"""
 
+    # The object type this collection holds
+    item_type = List
+
     def get_by_title(self, list_title):
         """Retrieve List client object by title"""
         return List(self.context,

--- a/office365/sharepoint/listitem.py
+++ b/office365/sharepoint/listitem.py
@@ -1,4 +1,3 @@
-from office365.runtime.client_object import ClientObject
 from office365.runtime.client_query import ClientQuery
 from office365.runtime.odata.odata_path_parser import ODataPathParser
 from office365.runtime.resource_path_entry import ResourcePathEntry
@@ -20,18 +19,24 @@ class ListItem(SecurableObject):
 
     @property
     def resource_path(self):
-        orig_path = ClientObject.resource_path.fget(self)
-        if self.is_property_available("Id") and "ParentList" in self.properties and orig_path is None:
+        resource_path = super(ListItem, self).resource_path
+        if resource_path:
+            return resource_path
+
+        # fallback: create a new resource path
+        if self.is_property_available("Id") and "ParentList" in self.properties:
             parent_list = self.properties["ParentList"]
             if '__deferred' in parent_list:
-                list_resource_path = ResourcePathEntry.from_uri(self.properties["ParentList"]['__deferred']['uri'],
-                                                                self.context)
+                list_resource_path = ResourcePathEntry.from_uri(
+                    self.properties["ParentList"]['__deferred']['uri'], self.context)
             else:
                 list_resource_path = parent_list.resource_path
-            return ResourcePathEntry(self.context,
-                                     list_resource_path,
-                                     ODataPathParser.from_method("getItemById", [self.properties["Id"]]))
-        return orig_path
+            self._resource_path = ResourcePathEntry(
+                self.context,
+                list_resource_path,
+                ODataPathParser.from_method("getItemById", [self.properties["Id"]]))
+
+        return self._resource_path
 
     @property
     def file(self):

--- a/office365/sharepoint/user.py
+++ b/office365/sharepoint/user.py
@@ -1,6 +1,7 @@
 from office365.runtime.client_query import ClientQuery
-from office365.sharepoint.principal import Principal
+from office365.runtime.odata.odata_path_parser import ODataPathParser
 from office365.runtime.resource_path_entry import ResourcePathEntry
+from office365.sharepoint.principal import Principal
 
 
 class User(Principal):
@@ -8,11 +9,11 @@ class User(Principal):
 
     @property
     def groups(self):
-        from office365.sharepoint.group_collection import GroupCollection
         """Gets a collection of group objects that represents all of the groups for the user."""
         if self.is_property_available('Groups'):
             return self.properties['Groups']
         else:
+            from office365.sharepoint.group_collection import GroupCollection
             return GroupCollection(self.context, ResourcePathEntry(self.context, self.resource_path, "Groups"))
 
     def delete_object(self):
@@ -20,3 +21,23 @@ class User(Principal):
         qry = ClientQuery.delete_entry_query(self)
         self.context.add_query(qry)
         self.remove_from_parent_collection()
+
+    @property
+    def resource_path(self):
+        resource_path = super(User, self).resource_path
+        if resource_path:
+            return resource_path
+
+        # fallback: create a new resource path
+        if self.is_property_available("Id"):
+            self._resource_path = ResourcePathEntry(
+                self.context,
+                ResourcePathEntry.from_uri("Web/SiteUsers", self.context),
+                ODataPathParser.from_method("GetById", [self.properties["Id"]]))
+        elif self.is_property_available("LoginName"):
+            self._resource_path = ResourcePathEntry(
+                self.context,
+                ResourcePathEntry.from_uri("Web/SiteUsers", self.context),
+                ODataPathParser.from_method("GetByName", [self.properties["LoginName"]]))
+
+        return self._resource_path

--- a/office365/sharepoint/user_collection.py
+++ b/office365/sharepoint/user_collection.py
@@ -6,6 +6,9 @@ from office365.sharepoint.user import User
 class UserCollection(ClientObjectCollection):
     """Represents a collection of User resources."""
 
+    # The object type this collection holds
+    item_type = User
+
     def get_by_email(self, email):
         """Retrieve User object by email"""
         return User(self.context, ResourcePathServiceOperation(self.context, self.resource_path, "GetByEmail", [email]))
@@ -19,9 +22,9 @@ class UserCollection(ClientObjectCollection):
         return User(self.context,
                     ResourcePathServiceOperation(self.context, self.resource_path, "GetByLoginName", [login_name]))
 
-    def remove_by_id(self, id):
+    def remove_by_id(self, _id):
         """Retrieve User object by id"""
-        return User(self.context, ResourcePathServiceOperation(self.context, self.resource_path, "RemoveById", [id]))
+        return User(self.context, ResourcePathServiceOperation(self.context, self.resource_path, "RemoveById", [_id]))
 
     def remove_by_login_name(self, login_name):
         """Remove User object by login name"""

--- a/office365/sharepoint/view_collection.py
+++ b/office365/sharepoint/view_collection.py
@@ -6,6 +6,9 @@ from office365.sharepoint.view import View
 class ViewCollection(ClientObjectCollection):
     """Represents a collection of View resources."""
 
+    # The object type this collection holds
+    item_type = View
+
     def get_by_title(self, view_title):
         """Gets the list view with the specified title."""
         return View(self.context,

--- a/office365/sharepoint/view_field_collection.py
+++ b/office365/sharepoint/view_field_collection.py
@@ -1,8 +1,12 @@
 from office365.runtime.client_object_collection import ClientObjectCollection
+from office365.sharepoint.field import Field
 
 
 class ViewFieldCollection(ClientObjectCollection):
     """Represents a collection of View resources."""
+
+    # The object type this collection holds
+    item_type = Field
 
     def __init__(self, context, resource_path=None):
         super(ViewFieldCollection, self).__init__(context, resource_path)

--- a/office365/sharepoint/web.py
+++ b/office365/sharepoint/web.py
@@ -1,7 +1,4 @@
-import urllib
-
 from office365.runtime.action_type import ActionType
-from office365.runtime.client_object import ClientObject
 from office365.runtime.resource_path_service_operation import ResourcePathServiceOperation
 from office365.sharepoint.file import File
 from office365.sharepoint.folder import Folder
@@ -13,7 +10,6 @@ from office365.runtime.client_query import ClientQuery
 from office365.runtime.resource_path_entry import ResourcePathEntry
 from office365.sharepoint.group_collection import GroupCollection
 from office365.sharepoint.list_collection import ListCollection
-from office365.sharepoint.web_collection import WebCollection
 
 
 class Web(SecurableObject):
@@ -64,6 +60,7 @@ class Web(SecurableObject):
         if self.is_property_available('Webs'):
             return self.properties['Webs']
         else:
+            from office365.sharepoint.web_collection import WebCollection
             return WebCollection(self.context, ResourcePathEntry(self.context, self.resource_path, "webs"))
 
     @property
@@ -108,7 +105,7 @@ class Web(SecurableObject):
 
     @property
     def service_root_url(self):
-        orig_root_url = ClientObject.service_root_url.fget(self)
+        orig_root_url = super(Web, self).service_root_url
         if self.is_property_available("Url"):
             cur_root_url = self.properties["Url"] + "/_api/"
             return cur_root_url

--- a/office365/sharepoint/web_collection.py
+++ b/office365/sharepoint/web_collection.py
@@ -1,15 +1,18 @@
 from office365.runtime.action_type import ActionType
 from office365.runtime.client_object_collection import ClientObjectCollection
 from office365.runtime.client_query import ClientQuery
+from office365.sharepoint.web import Web
 
 
 class WebCollection(ClientObjectCollection):
     """Web collection"""
 
+    # The object type this collection holds
+    item_type = Web
+
     def add(self, web_creation_information):
         web_creation_information._include_metadata = self.include_metadata
         payload = web_creation_information.payload
-        from office365.sharepoint.web import Web
         web = Web(self.context)
         qry = ClientQuery(self.url + "/add", ActionType.PostMethod, payload)
         self.context.add_query(qry, web)


### PR DESCRIPTION
While I was working with different types of collections and a custom selection of properties I stumbled upon some quirks. Newly created objects inside a collection need to create a new resource path themeself. I noticed a bug when using a query like `ctx.web.lists.select("Title")`. It would create a wrong resource path resulting in a request like `https://site/_api/web/GetByTitle('...')` (`lists` is missing), while using `ctx.web.lists.select("Id")` was ok. I found similar code in the other objects and decided to rework the resource path related functions.

This pull request does the following:

1. The method `create_typed_object` will now create objects types specified by the caller and does not rely on the List name anymore
2. The resource path for objects in a collection will be generated using the queried metadata

The code works with my use cases but is not fully tested.
