### PR TITLE
PyPI package: v2.1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="Office365-REST-Python-Client",
-    version="2.1.2",
+    version="2.1.3",
     author="Vadim Gremyachev",
     author_email="vvgrem@gmail.com",
     maintainer="Konrad Gądek",


### PR DESCRIPTION
Followup for the [recent release](https://github.com/vgrem/Office365-REST-Python-Client/releases/tag/2.1.3), package released to PyPI [[travis](https://travis-ci.org/kgadek/Office365-REST-Python-Client/builds/555998168)][[pypi](https://pypi.org/project/Office365-REST-Python-Client/2.1.3/)].