### PR TITLE
fix UnicodeDecodeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding='utf-8') as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
I am using Japanese Windows 10 and encountered the following error when installing.
```
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\KATO~1.TAK\AppData\Local\Temp\pip-install-btdpex4l\Office365-REST-Python-Client\setup.py", line 9, in <module>
        long_description = fh.read()
    UnicodeDecodeError: 'cp932' codec can't decode byte 0x93 in position 6346: illegal multibyte sequence
```