### PR TITLE
Catch errors on parsing authentication responses

### DIFF
--- a/office365/runtime/auth/saml_token_provider.py
+++ b/office365/runtime/auth/saml_token_provider.py
@@ -115,7 +115,10 @@ class SamlTokenProvider(BaseTokenProvider, office365.logger.LoggerContext):
         if xml.find('{0}Body/{0}Fault'.format(ns_prefixes['S'])) is not None:
             error = xml.find('{0}Body/{0}Fault/{0}Detail/{1}error/{1}internalerror/{1}text'.format(ns_prefixes['S'],
                                                                                                    ns_prefixes['psf']))
-            self.error = 'An error occurred while retrieving token: {0}'.format(error.text)
+            if error is None:
+                self.error = 'An error occurred while retrieving token from XML response.'
+            else:
+                self.error = 'An error occurred while retrieving token from XML response: {0}'.format(error.text)
             logger.error(self.error)
             return None
 
@@ -123,6 +126,10 @@ class SamlTokenProvider(BaseTokenProvider, office365.logger.LoggerContext):
         token = xml.find(
             '{0}Body/{1}RequestSecurityTokenResponse/{1}RequestedSecurityToken/{2}BinarySecurityToken'.format(
                 ns_prefixes['S'], ns_prefixes['wst'], ns_prefixes['wsse']))
+        if token is None:
+            self.error = 'The service token could not be extracted from the XML response.'
+            logger.error(self.error)
+            return None
         logger.debug_secrets("token: %s", token)
         return token.text
 


### PR DESCRIPTION
This pull request fixes multiple possible failure paths if the returned response from Sharepoint couldn't be parsed correctly.
In addition, the change fixes the propagation of parsing failures to the caller.

For example, if one provides wrong credentials, the code would fail with the following stack trace:
```
Traceback (most recent call last):
  File "<string>", line 208, in input
  File "<string>", line 52, in __init__
  File "<string>", line 68, in authenticate
  File ".../python-3.6.8/lib/site-packages/office365/runtime/auth/authentication_context.py", line 18, in acquire_token_for_user
    return self.provider.acquire_token()
  File ".../python-3.6.8/lib/site-packages/office365/runtime/auth/saml_token_provider.py", line 57, in acquire_token
    self.acquire_service_token(options)
  File ".../python-3.6.8/lib/site-packages/office365/runtime/auth/saml_token_provider.py", line 88, in acquire_service_token
    token = self.process_service_token_response(response)
  File ".../python-3.6.8/lib/site-packages/office365/runtime/auth/saml_token_provider.py", line 119, in process_service_token_response
    return token.text
AttributeError: 'NoneType' object has no attribute 'text'
```