### PR TITLE
Travis CI:fix deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+os: linux
 python:
   - "2.7"
   - "3.6"
@@ -14,19 +15,24 @@ stages:
     if: repo = "vgrem/Office365-REST-Python-Client"
   # Deploy is currently configured in maintainer's fork
   - name: deploy
-    if: repo = "vgrem/Office365-REST-Python-Client" AND tag IS present
 
 jobs:
+
+  # optionally set up exclusions and allowed failures in the matrix
+  allow_failures:
+    - python: "3.3"
+
   include:
     - stage: deploy
       python: 3.6
       script: true
       deploy:
         provider: pypi
-        user: kgadek
+        username: kgadek
         skip_existing: true
         password:
           secure: yEUHdUuAIVyU5UNtUo+9SVnQ//0E732eyb/yurA+dEx5M2THohzdX6T8jt+4xj4y0brtfSY1xOfNX4OW+yDXjsEZfOL7GZQSEkF+6LLRcO4gEJNYPXxDNe/N0/G1gN/w5d5jhzw6JUJaLsTzk5tmx51JYI6wMEHjYdM5948Mbja7Ya6h6wTIq0bmIu54OMUdcwdSXEFj3s3ZnxT8Qc57WS8Tg/ax1fL8JuPJNvOVe3qW9+NbFL01vosymLWqwOyhMkJp8J06nNtL3ijpZ/4uxITjRbKKRhcuMbBuTF5aV4FzONlxh+7lJ7ZvLWliB6HvYlJL1fQWj3ff/mxu8sa9YNeytGGfrZFeV/6AcqcJQnTj80vfwVKseL1Y4hqGMQey7kRGwUN1PjwaSQcAsqWcSDvgvb+LH4+c+Ha/LqM3ysQckR9FRFLarnX9wOhIUiLA3M9iEK7exCeOXstmJv3mGb774BetmrVT/Sp58SC8TVmbs/NbqukOkoUfTIwsOhNNSZPmpm/c6xjDXcVqdawAr4t6pjpy7q6yu9nuKJ7/V8A57Vm7o53O4CNwhkywPT9PVnDfzazj2a3Ech8BZ34nKugsz1o5r8fVRrdfbtcNR+NN3/TuuYYTLmM4JMkngc8XJNxubnHt53oCxyLsbuCr8VqlGTVQ+AH+2HpDZQ3be5I=
         on:
           tags: true
+          repo: "kgadek/Office365-REST-Python-Client"
 


### PR DESCRIPTION
I found out that `.travis.yml` had incorrect syntax. It's peculiar why it worked previously.

Anyhow, along with this PR I've made:
- tag `2.1.6-2` in my fork, please pull
- [PyPI release `2.1.6-2`](https://pypi.org/project/Office365-REST-Python-Client/2.1.6.post2/) (essentially 2.1.6-1 with `.travis.yml` changes)
- tag `2.1.7-1`
- [PyPI release `2.1.7-1`](https://pypi.org/project/Office365-REST-Python-Client/2.1.7.post1/) (ditto as `2.1.6-2`)

Closes vgrem/Office365-REST-Python-Client#167