### PR TITLE
SearchRequest: added selected_properties and refinement_filters

### DIFF
--- a/office365/sharepoint/search/searchRequest.py
+++ b/office365/sharepoint/search/searchRequest.py
@@ -3,17 +3,21 @@ from office365.runtime.clientValue import ClientValue
 
 class SearchRequest(ClientValue):
 
-    def __init__(self, query_text, blockDedupeMode=None, bypassResultTypes=None):
+    def __init__(self, query_text, selected_properties=None, refinement_filters=None,
+                 blockDedupeMode=None, bypassResultTypes=None):
         """
 
-        :type bypassResultTypes: bool
-        :type blockDedupeMode: int
         :type query_text: str
+        :type selected_properties: dict
+        :type refinement_filters: dict
+        :type blockDedupeMode: int
         """
         super().__init__()
         self.Querytext = query_text
         self.BlockDedupeMode = blockDedupeMode
         self.BypassResultTypes = bypassResultTypes
+        self.SelectProperties = selected_properties
+        self.RefinementFilters = refinement_filters
         self.ClientType = None
         self.CollapseSpecification = None
         self.Culture = None


### PR DESCRIPTION
Following https://docs.microsoft.com/en-us/sharepoint/dev/general-development/sharepoint-search-rest-api-overview#post-requests

we may need to be able to manipulate more the Search Request

selected_properties = {'results':['Title','Path','FileExtension','CustomMetadata1','CustomMetadata2']}
request = SearchRequest(qry, selected_properties=selected_properties)

@vgrem what do you think?