### PR TITLE
drop python 2.7 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 os: linux
 python:
-- '3.5'
 - '3.6'
 - '3.7'
 - '3.8'

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ pip install Office365-REST-Python-Client
 ```
 
 ### Note 
+>This library requires python >= 3.6
 >
 >Since PyPI default index `Office365-REST-Python-Client` has not been updated for a while 
 > and the last version available from index is already considered _outdated_, 

--- a/generator/type_builder.py
+++ b/generator/type_builder.py
@@ -3,7 +3,7 @@ import ast
 import astunparse
 
 
-class TypeBuilder(object):
+class TypeBuilder:
 
     def __init__(self, schema):
         self._schema = schema

--- a/office365/actions/download_content_query.py
+++ b/office365/actions/download_content_query.py
@@ -13,4 +13,4 @@ class DownloadContentQuery(ServiceOperationQuery):
         action_name = "content"
         if format_name is not None:
             action_name = action_name + r"?format={0}".format(format_name)
-        super(DownloadContentQuery, self).__init__(entity_type, action_name, None, None, None, result)
+        super().__init__(entity_type, action_name, None, None, None, result)

--- a/office365/actions/search_query.py
+++ b/office365/actions/search_query.py
@@ -3,4 +3,4 @@ from office365.runtime.queries.service_operation_query import ServiceOperationQu
 
 class SearchQuery(ServiceOperationQuery):
     def __init__(self, entity_type, query_text, return_type):
-        super(SearchQuery, self).__init__(entity_type, "search", {"q": query_text}, None, None, return_type)
+        super().__init__(entity_type, "search", {"q": query_text}, None, None, return_type)

--- a/office365/actions/upload_content_query.py
+++ b/office365/actions/upload_content_query.py
@@ -6,4 +6,4 @@ from office365.runtime.queries.service_operation_query import ServiceOperationQu
 class UploadContentQuery(ServiceOperationQuery):
     def __init__(self, parent_entity, name, content):
         return_type = DriveItem(parent_entity.context, ResourcePathUrl(name, parent_entity.resource_path))
-        super(UploadContentQuery, self).__init__(return_type, "content", None, content, None, return_type)
+        super().__init__(return_type, "content", None, content, None, return_type)

--- a/office365/directory/directoryObject.py
+++ b/office365/directory/directoryObject.py
@@ -43,4 +43,4 @@ class DirectoryObject(Entity):
         return None
 
     def set_property(self, name, value, persist_changes=True):
-        super(DirectoryObject, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)

--- a/office365/directory/directoryObjectCollection.py
+++ b/office365/directory/directoryObjectCollection.py
@@ -10,10 +10,10 @@ class DirectoryObjectCollection(EntityCollection):
     """DirectoryObject's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(DirectoryObjectCollection, self).__init__(context, DirectoryObject, resource_path)
+        super().__init__(context, DirectoryObject, resource_path)
 
     def get(self):
-        return super(DirectoryObjectCollection, self).get()
+        return super().get()
 
     def __getitem__(self, key):
         """
@@ -24,7 +24,7 @@ class DirectoryObjectCollection(EntityCollection):
         :rtype: DirectoryObject
         """
         if type(key) == int:
-            return super(DirectoryObjectCollection, self).__getitem__(key)
+            return super().__getitem__(key)
         return self._item_type(self.context,
                                ResourcePath(key, self.resource_path))
 

--- a/office365/directory/group.py
+++ b/office365/directory/group.py
@@ -35,7 +35,7 @@ class Group(DirectoryObject):
         :type permanent_delete: bool
 
         """
-        super(Group, self).delete_object()
+        super().delete_object()
         if permanent_delete:
             deleted_item = self.context.directory.deletedGroups[self.id]
             deleted_item.delete_object()
@@ -77,7 +77,7 @@ class Group(DirectoryObject):
                                   ResourcePath("sites", self.resource_path))
 
     def set_property(self, name, value, persist_changes=True):
-        super(Group, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: create a new resource path
         if self._resource_path is None:
             if name == "id":

--- a/office365/directory/groupCollection.py
+++ b/office365/directory/groupCollection.py
@@ -7,7 +7,7 @@ class GroupCollection(DirectoryObjectCollection):
     """Group's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(GroupCollection, self).__init__(context, resource_path)
+        super().__init__(context, resource_path)
         self._item_type = Group
 
     def add(self, group_properties):

--- a/office365/directory/groupProfile.py
+++ b/office365/directory/groupProfile.py
@@ -7,7 +7,7 @@ class GroupProfile(ClientValue):
 
         :param str name: Group name
         """
-        super(GroupProfile, self).__init__()
+        super().__init__()
         self.mailNickname = name
         self.displayName = name
         self.description = None

--- a/office365/directory/groupSettingTemplateCollection.py
+++ b/office365/directory/groupSettingTemplateCollection.py
@@ -6,5 +6,5 @@ class GroupSettingTemplateCollection(DirectoryObjectCollection):
     """User's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(GroupSettingTemplateCollection, self).__init__(context, resource_path)
+        super().__init__(context, resource_path)
         self._item_type = GroupSettingTemplate

--- a/office365/directory/identity.py
+++ b/office365/directory/identity.py
@@ -6,6 +6,6 @@ class Identity(ClientValue):
     or application. """
 
     def __init__(self):
-        super(Identity, self).__init__()
+        super().__init__()
         self.displayName = None
         self.id = None

--- a/office365/directory/identitySet.py
+++ b/office365/directory/identitySet.py
@@ -7,7 +7,7 @@ class IdentitySet(ClientValue):
     identities associated with various events for an item, such as created by or last modified by. """
 
     def __init__(self):
-        super(IdentitySet, self).__init__()
+        super().__init__()
         self.application = Identity()
         self.device = Identity()
         self.user = Identity()

--- a/office365/directory/passwordProfile.py
+++ b/office365/directory/passwordProfile.py
@@ -5,6 +5,6 @@ class PasswordProfile(ClientValue):
     """Contains the password profile associated with a user. The passwordProfile property of the user entity is a
     passwordProfile object. """
     def __init__(self, password):
-        super(PasswordProfile, self).__init__()
+        super().__init__()
         self.password = password
         self.forceChangePasswordNextSignIn = True

--- a/office365/directory/permission_collection.py
+++ b/office365/directory/permission_collection.py
@@ -6,4 +6,4 @@ class PermissionCollection(EntityCollection):
     """Permission's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(PermissionCollection, self).__init__(context, Permission, resource_path)
+        super().__init__(context, Permission, resource_path)

--- a/office365/directory/user.py
+++ b/office365/directory/user.py
@@ -18,7 +18,7 @@ class User(DirectoryObject):
         :type permanent_delete: bool
 
         """
-        super(User, self).delete_object()
+        super().delete_object()
         if permanent_delete:
             deleted_user = self.context.directory.deletedUsers[self.id]
             deleted_user.delete_object()
@@ -89,7 +89,7 @@ class User(DirectoryObject):
             return DirectoryObjectCollection(self.context, ResourcePath("transitiveMemberOf", self.resource_path))
 
     def set_property(self, name, value, persist_changes=True):
-        super(User, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: create a new resource path
         if self._resource_path is None:
             if name == "id" or name == "userPrincipalName":

--- a/office365/directory/userCollection.py
+++ b/office365/directory/userCollection.py
@@ -7,7 +7,7 @@ class UserCollection(DirectoryObjectCollection):
     """User's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(UserCollection, self).__init__(context, resource_path)
+        super().__init__(context, resource_path)
         self._item_type = User
 
     def __getitem__(self, key):
@@ -15,7 +15,7 @@ class UserCollection(DirectoryObjectCollection):
 
         :rtype: User
         """
-        return super(UserCollection, self).__getitem__(key)
+        return super().__getitem__(key)
 
     def add(self, user_properties):
         """Create a new user.

--- a/office365/directory/userProfile.py
+++ b/office365/directory/userProfile.py
@@ -12,7 +12,7 @@ class UserProfile(ClientValue):
         :type display_name: str
         :type account_enabled: bool
         """
-        super(UserProfile, self).__init__()
+        super().__init__()
         self.userPrincipalName = principal_name
         self.passwordProfile = PasswordProfile(password)
         self.mailNickname = principal_name.split("@")[0]

--- a/office365/entity.py
+++ b/office365/entity.py
@@ -25,7 +25,7 @@ class Entity(ClientObject):
         return None
 
     def set_property(self, name, value, persist_changes=True):
-        super(Entity, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         if name == "id" and self._resource_path is None:
             self._resource_path = ResourcePath(
                 value,

--- a/office365/entity_collection.py
+++ b/office365/entity_collection.py
@@ -13,7 +13,7 @@ class EntityCollection(ClientObjectCollection):
         :rtype: EntityCollection
         """
         if type(key) == int:
-            return super(EntityCollection, self).__getitem__(key)
+            return super().__getitem__(key)
         return self._item_type(self.context, ResourcePath(key, self.resource_path))
 
     @property

--- a/office365/graph_client.py
+++ b/office365/graph_client.py
@@ -33,7 +33,7 @@ class GraphClient(ClientRuntimeContext):
         :param (adal.AuthenticationContext) -> dict acquire_token_callback: Acquire token function
         :param str tenant: Tenant name
         """
-        super(GraphClient, self).__init__()
+        super().__init__()
         self._pending_request = ODataRequest(self, V4JsonFormat("minimal"))
         self._pending_request.beforeExecute += self._build_specific_query
         self._resource = "https://graph.microsoft.com"

--- a/office365/onedrive/columnDefinitionCollection.py
+++ b/office365/onedrive/columnDefinitionCollection.py
@@ -6,4 +6,4 @@ class ColumnDefinitionCollection(ClientObjectCollection):
     """Drive column's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(ColumnDefinitionCollection, self).__init__(context, ColumnDefinition, resource_path)
+        super().__init__(context, ColumnDefinition, resource_path)

--- a/office365/onedrive/contentTypeCollection.py
+++ b/office365/onedrive/contentTypeCollection.py
@@ -6,4 +6,4 @@ class ContentTypeCollection(ClientObjectCollection):
     """Drive column's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(ContentTypeCollection, self).__init__(context, ContentType, resource_path)
+        super().__init__(context, ContentType, resource_path)

--- a/office365/onedrive/driveCollection.py
+++ b/office365/onedrive/driveCollection.py
@@ -7,7 +7,7 @@ class DriveCollection(ClientObjectCollection):
     """Drive's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(DriveCollection, self).__init__(context, Drive, resource_path)
+        super().__init__(context, Drive, resource_path)
 
     def __getitem__(self, key):
         """
@@ -17,5 +17,5 @@ class DriveCollection(ClientObjectCollection):
         :type key: int or str
         """
         if type(key) == int:
-            return super(DriveCollection, self).__getitem__(key)
+            return super().__getitem__(key)
         return Drive(self.context, ResourcePath(key, self.resource_path))

--- a/office365/onedrive/driveItem.py
+++ b/office365/onedrive/driveItem.py
@@ -332,7 +332,7 @@ class DriveItem(BaseItem):
                                                                                          self.resource_path)))
 
     def set_property(self, name, value, persist_changes=True):
-        super(DriveItem, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         if name == "id" and self._resource_path.parent.segment == "children":
             self._resource_path = ResourcePath(
                 value,

--- a/office365/onedrive/driveItemCollection.py
+++ b/office365/onedrive/driveItemCollection.py
@@ -8,7 +8,7 @@ class DriveItemCollection(ClientObjectCollection):
     """Drive items's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(DriveItemCollection, self).__init__(context, DriveItem, resource_path)
+        super().__init__(context, DriveItem, resource_path)
 
     def get_by_id(self, _id):
         """Retrieve DriveItem by id"""

--- a/office365/onedrive/driveItemVersionCollection.py
+++ b/office365/onedrive/driveItemVersionCollection.py
@@ -5,4 +5,4 @@ from office365.runtime.client_object_collection import ClientObjectCollection
 class DriveItemVersionCollection(ClientObjectCollection):
 
     def __init__(self, context, resource_path=None):
-        super(DriveItemVersionCollection, self).__init__(context, DriveItemVersion, resource_path)
+        super().__init__(context, DriveItemVersion, resource_path)

--- a/office365/onedrive/driveRecipient.py
+++ b/office365/onedrive/driveRecipient.py
@@ -4,7 +4,7 @@ from office365.runtime.client_value import ClientValue
 class DriveRecipient(ClientValue):
 
     def __init__(self):
-        super(DriveRecipient, self).__init__()
+        super().__init__()
         self.alias = None
         self.email = None
         self.objectId = None

--- a/office365/onedrive/file.py
+++ b/office365/onedrive/file.py
@@ -4,7 +4,7 @@ from office365.runtime.client_value import ClientValue
 class File(ClientValue):
 
     def __init__(self):
-        super(File, self).__init__()
+        super().__init__()
         self.hashes = None
         self.mimeType = None
         self.processingMetadata = None

--- a/office365/onedrive/fileSystemInfo.py
+++ b/office365/onedrive/fileSystemInfo.py
@@ -6,7 +6,7 @@ class FileSystemInfo(ClientValue):
     local version of an item. """
 
     def __init__(self):
-        super(FileSystemInfo, self).__init__()
+        super().__init__()
         self.createdDateTime = None
         self.lastAccessedDateTime = None
         self.lastModifiedDateTime = None

--- a/office365/onedrive/file_upload.py
+++ b/office365/onedrive/file_upload.py
@@ -15,7 +15,7 @@ def read_in_chunks(file_object, chunk_size=1024):
         yield data
 
 
-class ResumableFileUpload(object):
+class ResumableFileUpload:
     """Create an upload session to allow your app to upload files up to the maximum file size. An upload session
     allows your app to upload ranges of the file in sequential API requests, which allows the transfer to be resumed
     if a connection is dropped while the upload is in progress. """

--- a/office365/onedrive/folder.py
+++ b/office365/onedrive/folder.py
@@ -9,6 +9,6 @@ class Folder(ClientValue):
         :param int childCount:
         :param office365.onedrive.folderView.FolderView view:
         """
-        super(Folder, self).__init__()
+        super().__init__()
         self.childCount = childCount
         self.view = view

--- a/office365/onedrive/listCollection.py
+++ b/office365/onedrive/listCollection.py
@@ -7,7 +7,7 @@ class ListCollection(ClientObjectCollection):
     """Drive list's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(ListCollection, self).__init__(context, List, resource_path)
+        super().__init__(context, List, resource_path)
 
     def add(self, list_creation_information):
         """Creates a Drive list resource"""

--- a/office365/onedrive/listItemCollection.py
+++ b/office365/onedrive/listItemCollection.py
@@ -6,4 +6,4 @@ class ListItemCollection(ClientObjectCollection):
     """Drive list item's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(ListItemCollection, self).__init__(context, ListItem, resource_path)
+        super().__init__(context, ListItem, resource_path)

--- a/office365/onedrive/publicationFacet.py
+++ b/office365/onedrive/publicationFacet.py
@@ -9,6 +9,6 @@ class PublicationFacet(ClientValue):
         :param str level: The state of publication for this document. Either published or checkout. Read-only.
         :param str versionId: The unique identifier for the version that is visible to the current caller. Read-only.
         """
-        super(PublicationFacet, self).__init__()
+        super().__init__()
         self.level = level
         self.versionId = versionId

--- a/office365/onedrive/shared.py
+++ b/office365/onedrive/shared.py
@@ -10,5 +10,5 @@ class Shared(ClientValue):
 
         :type owner: office365.directory.identitySet.IdentitySet
         """
-        super(Shared, self).__init__()
+        super().__init__()
         self.owner = owner

--- a/office365/onedrive/sharedDriveItemCollection.py
+++ b/office365/onedrive/sharedDriveItemCollection.py
@@ -6,4 +6,4 @@ class SharedDriveItemCollection(ClientObjectCollection):
     """sharedDriveItem's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(SharedDriveItemCollection, self).__init__(context, SharedDriveItem, resource_path)
+        super().__init__(context, SharedDriveItem, resource_path)

--- a/office365/onedrive/site.py
+++ b/office365/onedrive/site.py
@@ -70,7 +70,7 @@ class Site(BaseItem):
                                   ResourcePath("sites", self.resource_path))
 
     def set_property(self, name, value, persist_changes=True):
-        super(Site, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         if name == "id" and self._resource_path.segment == "root":
             self._resource_path = ResourcePath(value, self._resource_path.parent)
         return self

--- a/office365/onedrive/siteCollection.py
+++ b/office365/onedrive/siteCollection.py
@@ -7,7 +7,7 @@ class SiteCollection(ClientObjectCollection):
     """Drive site's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(SiteCollection, self).__init__(context, Site, resource_path)
+        super().__init__(context, Site, resource_path)
 
     @property
     def root(self):

--- a/office365/onedrive/siteCollectionType.py
+++ b/office365/onedrive/siteCollectionType.py
@@ -5,7 +5,7 @@ class SiteCollectionType(ClientValue):
     """The siteCollection resource provides more information about a site collection. """
 
     def __init__(self):
-        super(SiteCollectionType, self).__init__()
+        super().__init__()
         self._hostname = None
         self._root = None
 

--- a/office365/outlookservices/attachment_collection.py
+++ b/office365/outlookservices/attachment_collection.py
@@ -6,4 +6,4 @@ class AttachmentCollection(ClientObjectCollection):
     """Attachment collection"""
 
     def __init__(self, context, resource_path=None):
-        super(AttachmentCollection, self).__init__(context, Attachment, resource_path)
+        super().__init__(context, Attachment, resource_path)

--- a/office365/outlookservices/contact_collection.py
+++ b/office365/outlookservices/contact_collection.py
@@ -8,7 +8,7 @@ class ContactCollection(ClientObjectCollection):
     """User's contact collection"""
 
     def __init__(self, context, resource_path=None):
-        super(ContactCollection, self).__init__(context, Contact, resource_path)
+        super().__init__(context, Contact, resource_path)
 
     def add_from_json(self, contact_creation_information):
         """Creates a Contact resource from JSON"""

--- a/office365/outlookservices/event_collection.py
+++ b/office365/outlookservices/event_collection.py
@@ -6,7 +6,7 @@ from office365.runtime.queries.create_entity_query import CreateEntityQuery
 class EventCollection(ClientObjectCollection):
     """Event's collection"""
     def __init__(self, context, resource_path=None):
-        super(EventCollection, self).__init__(context, Event, resource_path)
+        super().__init__(context, Event, resource_path)
 
     def add_from_json(self, event_creation_information):
         """Creates a Event resource from JSON"""

--- a/office365/outlookservices/messageCollection.py
+++ b/office365/outlookservices/messageCollection.py
@@ -6,7 +6,7 @@ from office365.runtime.queries.create_entity_query import CreateEntityQuery
 class MessageCollection(ClientObjectCollection):
     """Message's collection"""
     def __init__(self, context, resource_path=None):
-        super(MessageCollection, self).__init__(context, Message, resource_path)
+        super().__init__(context, Message, resource_path)
 
     def add_from_json(self, message_creation_information):
         """Create a draft of a new message from JSON"""

--- a/office365/outlookservices/outlook_client.py
+++ b/office365/outlookservices/outlook_client.py
@@ -19,7 +19,7 @@ class OutlookClient(ClientRuntimeContext):
         :type auth_context: AuthenticationContext
         """
         self._resource = "https://outlook.office365.com"
-        super(OutlookClient, self).__init__(auth_context)
+        super().__init__(auth_context)
         self._pendingRequest = ODataRequest(self, V4JsonFormat("minimal"))
         self._pendingRequest.beforeExecute += self._build_specific_query
 

--- a/office365/outlookservices/outlook_entity.py
+++ b/office365/outlookservices/outlook_entity.py
@@ -19,7 +19,7 @@ class OutlookEntity(ClientObject):
         return self
 
     def set_property(self, name, value, persist_changes=True):
-        super(OutlookEntity, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: create a new resource path
         if name.lower() == "id":
             self._resource_path = ResourcePath(

--- a/office365/outlookservices/physical_address.py
+++ b/office365/outlookservices/physical_address.py
@@ -5,4 +5,4 @@ class PhysicalAddress(ClientObject):
     """The physical address of a contact."""
 
     def __init__(self, context):
-        super(PhysicalAddress, self).__init__(context)
+        super().__init__(context)

--- a/office365/resource_path_url.py
+++ b/office365/resource_path_url.py
@@ -5,7 +5,7 @@ class ResourcePathUrl(ResourcePath):
     """Resource path for OneDrive path-based addressing"""
 
     def __init__(self, url, parent):
-        super(ResourcePathUrl, self).__init__(url, parent)
+        super().__init__(url, parent)
 
     def to_url(self):
         return self._parent.to_url() + ":/{0}:/".format(self.segment)

--- a/office365/runtime/auth/authentication_context.py
+++ b/office365/runtime/auth/authentication_context.py
@@ -13,7 +13,7 @@ class AuthenticationContext(BaseAuthenticationContext):
 
         :param str url:  authority url
         """
-        super(AuthenticationContext, self).__init__()
+        super().__init__()
         self.url = url
         self.provider = None
         self.acquire_token_func = None

--- a/office365/runtime/auth/base_token_provider.py
+++ b/office365/runtime/auth/base_token_provider.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 
 
-class BaseTokenProvider(object):
+class BaseTokenProvider:
     """ Base token provider"""
     __metaclass__ = ABCMeta
 

--- a/office365/runtime/auth/client_credential.py
+++ b/office365/runtime/auth/client_credential.py
@@ -1,4 +1,4 @@
-class ClientCredential(object):
+class ClientCredential:
 
     def __init__(self, client_id, client_secret):
         """

--- a/office365/runtime/auth/network_credential_context.py
+++ b/office365/runtime/auth/network_credential_context.py
@@ -5,7 +5,7 @@ class NetworkCredentialContext(BaseAuthenticationContext):
     """Provides credentials for password-based authentication schemes such as basic authentication"""
 
     def __init__(self, username, password):
-        super(NetworkCredentialContext, self).__init__()
+        super().__init__()
         self.userCredentials = (username, password)
 
     def authenticate_request(self, request_options):

--- a/office365/runtime/auth/ntlm_authentication_context.py
+++ b/office365/runtime/auth/ntlm_authentication_context.py
@@ -19,7 +19,7 @@ class NTLMAuthenticationContext(NetworkCredentialContext):
             :type username: str
             :type password: str
         """
-        super(NTLMAuthenticationContext, self).__init__(username, password)
+        super().__init__(username, password)
         self.auth = HttpNtlmAuth(*self.userCredentials)
 
     def authenticate_request(self, request_options):

--- a/office365/runtime/auth/sts_profile.py
+++ b/office365/runtime/auth/sts_profile.py
@@ -1,7 +1,7 @@
 import datetime
 
 
-class STSProfile(object):
+class STSProfile:
 
     def __init__(self, authority_url):
         """

--- a/office365/runtime/auth/token_response.py
+++ b/office365/runtime/auth/token_response.py
@@ -1,4 +1,4 @@
-class TokenResponse(object):
+class TokenResponse:
 
     def __init__(self, accessToken=None, tokenType=None, **kwargs):
         self.accessToken = accessToken

--- a/office365/runtime/auth/user_credential.py
+++ b/office365/runtime/auth/user_credential.py
@@ -1,4 +1,4 @@
-class UserCredential(object):
+class UserCredential:
 
     def __init__(self, user_name, password):
         """

--- a/office365/runtime/auth/user_realm_info.py
+++ b/office365/runtime/auth/user_realm_info.py
@@ -1,4 +1,4 @@
-class UserRealmInfo(object):
+class UserRealmInfo:
 
     def __init__(self, auth_url, federated):
         """

--- a/office365/runtime/client_object.py
+++ b/office365/runtime/client_object.py
@@ -4,7 +4,7 @@ from office365.runtime.client_value import ClientValue
 from office365.runtime.odata.odata_query_options import QueryOptions
 
 
-class ClientObject(object):
+class ClientObject:
 
     def __init__(self, context, resource_path=None, properties=None, parent_collection=None):
         """

--- a/office365/runtime/client_object_collection.py
+++ b/office365/runtime/client_object_collection.py
@@ -13,7 +13,7 @@ class ClientObjectCollection(ClientObject):
         :type item_type: type[ClientObject]
         :type resource_path: office365.runtime.resource_path.ResourcePath
         """
-        super(ClientObjectCollection, self).__init__(context, resource_path)
+        super().__init__(context, resource_path)
         self._data = []
         self._item_type = item_type
         self.page_loaded = EventHandler(False)
@@ -26,7 +26,7 @@ class ClientObjectCollection(ClientObject):
         """
         :rtype: ClientObjectCollection
         """
-        return super(ClientObjectCollection, self).get()
+        return super().get()
 
     def clear(self):
         self._data = []

--- a/office365/runtime/client_request.py
+++ b/office365/runtime/client_request.py
@@ -8,7 +8,7 @@ from office365.runtime.http.http_method import HttpMethod
 from office365.runtime.types.EventHandler import EventHandler
 
 
-class ClientRequest(object):
+class ClientRequest:
 
     def __init__(self, context):
         """

--- a/office365/runtime/client_request_exception.py
+++ b/office365/runtime/client_request_exception.py
@@ -3,7 +3,7 @@ from requests import RequestException
 
 class ClientRequestException(RequestException):
     def __init__(self, *args, **kwargs):
-        super(ClientRequestException, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         content_type = self.response.headers.get('Content-Type', '').lower().split(';')[0]
         if self.response.content and content_type == 'application/json':
             self.payload = self.response.json()

--- a/office365/runtime/client_response.py
+++ b/office365/runtime/client_response.py
@@ -1,2 +1,2 @@
-class ClientResponse(object):
+class ClientResponse:
     """Client response """

--- a/office365/runtime/client_result.py
+++ b/office365/runtime/client_result.py
@@ -2,7 +2,7 @@ from office365.runtime.client_object import ClientObject
 from office365.runtime.client_value import ClientValue
 
 
-class ClientResult(object):
+class ClientResult:
     """Client result"""
 
     def __init__(self, value):

--- a/office365/runtime/client_runtime_context.py
+++ b/office365/runtime/client_runtime_context.py
@@ -5,7 +5,7 @@ from office365.runtime.client_request_exception import ClientRequestException
 from office365.runtime.queries.read_entity_query import ReadEntityQuery
 
 
-class ClientRuntimeContext(object):
+class ClientRuntimeContext:
 
     def __init__(self, auth_context=None):
         """

--- a/office365/runtime/client_value.py
+++ b/office365/runtime/client_value.py
@@ -1,11 +1,11 @@
-class ClientValue(object):
+class ClientValue:
     """Represent complex type.
     Complex types consist of a list of properties with no key, and can therefore only exist as properties of a
     containing entity or as a temporary value
     """
 
     def __init__(self, namespace=None):
-        super(ClientValue, self).__init__()
+        super().__init__()
         self._namespace = namespace
 
     def set_property(self, k, v, persist_changes=True):

--- a/office365/runtime/http/request_options.py
+++ b/office365/runtime/http/request_options.py
@@ -1,7 +1,7 @@
 from office365.runtime.http.http_method import HttpMethod
 
 
-class RequestOptions(object):
+class RequestOptions:
     """Request options"""
 
     def __init__(self, url):

--- a/office365/runtime/odata/json_light_format.py
+++ b/office365/runtime/odata/json_light_format.py
@@ -6,7 +6,7 @@ class JsonLightFormat(ODataJsonFormat):
     """JSON Light format for SharePoint Online/One Drive for Business"""
 
     def __init__(self, metadata=ODataMetadataLevel.Verbose):
-        super(JsonLightFormat, self).__init__(metadata)
+        super().__init__(metadata)
         if self.metadata == ODataMetadataLevel.Verbose:
             self.security_tag_name = "d"
             self.collection_tag_name = "results"

--- a/office365/runtime/odata/odata_base_reader.py
+++ b/office365/runtime/odata/odata_base_reader.py
@@ -4,7 +4,7 @@ from xml.etree import ElementTree as ET
 from office365.runtime.odata.odata_model import ODataModel
 
 
-class ODataBaseReader(object):
+class ODataBaseReader:
     """OData reader"""
 
     def __init__(self, options):

--- a/office365/runtime/odata/odata_batch_request.py
+++ b/office365/runtime/odata/odata_batch_request.py
@@ -12,7 +12,7 @@ from office365.runtime.queries.batch_query import BatchQuery, create_boundary
 class ODataBatchRequest(ClientRequest):
 
     def __init__(self, context):
-        super(ODataBatchRequest, self).__init__(context)
+        super().__init__(context)
 
     def build_request(self):
         url = "{0}$batch".format(self.context.service_root_url())

--- a/office365/runtime/odata/odata_json_format.py
+++ b/office365/runtime/odata/odata_json_format.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 
 
-class ODataJsonFormat(object):
+class ODataJsonFormat:
     """OData JSON format"""
 
     def __init__(self, metadata=None):

--- a/office365/runtime/odata/odata_model.py
+++ b/office365/runtime/odata/odata_model.py
@@ -1,7 +1,7 @@
 from pydoc import locate
 
 
-class ODataModel(object):
+class ODataModel:
     """OData model"""
     _types = {}
     _namespaces = ['principal', 'onedrive', 'outlookservices', 'teams']

--- a/office365/runtime/odata/odata_path_parser.py
+++ b/office365/runtime/odata/odata_path_parser.py
@@ -3,7 +3,7 @@ import json
 from office365.runtime.client_value import ClientValue
 
 
-class ODataPathParser(object):
+class ODataPathParser:
     @staticmethod
     def parse_path_string(string):
         pass

--- a/office365/runtime/odata/odata_query_options.py
+++ b/office365/runtime/odata/odata_query_options.py
@@ -4,7 +4,7 @@ def _normalize(key, value):
     return value
 
 
-class QueryOptions(object):
+class QueryOptions:
 
     def __init__(self, select=None, expand=None, filter_expr=None, orderBy=None, top=None, skip=None):
         """

--- a/office365/runtime/odata/odata_request.py
+++ b/office365/runtime/odata/odata_request.py
@@ -22,7 +22,7 @@ class ODataRequest(ClientRequest):
         :type context: office365.runtime.client_runtime_context.ClientRuntimeContext
         :type json_format: office365.runtime.odata.odata_json_format.ODataJsonFormat
         """
-        super(ODataRequest, self).__init__(context)
+        super().__init__(context)
         self._json_format = json_format
 
     @property
@@ -31,7 +31,7 @@ class ODataRequest(ClientRequest):
 
     def execute_request_direct(self, request):
         self.ensure_media_type(request)
-        return super(ODataRequest, self).execute_request_direct(request)
+        return super().execute_request_direct(request)
 
     def build_request(self):
         qry = self.current_query

--- a/office365/runtime/odata/v4_json_format.py
+++ b/office365/runtime/odata/v4_json_format.py
@@ -5,7 +5,7 @@ class V4JsonFormat(ODataJsonFormat):
     """V4 JSON format"""
 
     def __init__(self, metadata):
-        super(V4JsonFormat, self).__init__(metadata)
+        super().__init__(metadata)
         """The IEEE754Compatible format parameter indicates that the service MUST serialize Edm.Int64 and
         Edm.Decimal numbers as strings."""
         self.IEEE754Compatible = False

--- a/office365/runtime/queries/client_query.py
+++ b/office365/runtime/queries/client_query.py
@@ -1,6 +1,6 @@
 
 
-class ClientQuery(object):
+class ClientQuery:
     """Client query"""
 
     def __init__(self, context, binding_type=None, parameter_type=None, parameter_name=None, return_type=None):

--- a/office365/runtime/queries/create_entity_query.py
+++ b/office365/runtime/queries/create_entity_query.py
@@ -10,8 +10,8 @@ class CreateEntityQuery(ClientQuery):
         :type parameters: ClientObject or ClientValue or dict
         :type parent_entity: office365.runtime.client_object.ClientObject
         """
-        super(CreateEntityQuery, self).__init__(parent_entity.context,
-                                                parent_entity,
-                                                parameters,
-                                                None,
-                                                entity_to_create)
+        super().__init__(parent_entity.context,
+                         parent_entity,
+                         parameters,
+                         None,
+                         entity_to_create)

--- a/office365/runtime/queries/delete_entity_query.py
+++ b/office365/runtime/queries/delete_entity_query.py
@@ -8,4 +8,4 @@ class DeleteEntityQuery(ClientQuery):
 
         :type entity_to_delete: office365.runtime.client_object.ClientObject
         """
-        super(DeleteEntityQuery, self).__init__(entity_to_delete.context, entity_to_delete)
+        super().__init__(entity_to_delete.context, entity_to_delete)

--- a/office365/runtime/queries/read_entity_query.py
+++ b/office365/runtime/queries/read_entity_query.py
@@ -11,11 +11,11 @@ class ReadEntityQuery(ClientQuery):
         :type properties_to_include: list[str] or None
         :type entity_to_read: office365.runtime.client_object.ClientObject
         """
-        super(ReadEntityQuery, self).__init__(entity_to_read.context, entity_to_read, None, None, entity_to_read)
+        super().__init__(entity_to_read.context, entity_to_read, None, None, entity_to_read)
         self._properties_to_include = properties_to_include
 
     def build_url(self):
-        url = super(ReadEntityQuery, self).build_url()
+        url = super().build_url()
         if self._properties_to_include:
             url += "?" + self._build_query_url()
         return url

--- a/office365/runtime/queries/service_operation_query.py
+++ b/office365/runtime/queries/service_operation_query.py
@@ -14,7 +14,7 @@ class ServiceOperationQuery(ClientQuery):
         :type method_params: list or dict or office365.runtime.client_value.ClientValue or None
         :type method_name: str or None
         """
-        super(ServiceOperationQuery, self).__init__(binding_type.context,
+        super().__init__(binding_type.context,
                                                     binding_type,
                                                     parameter_type,
                                                     parameter_name,

--- a/office365/runtime/queries/update_entity_query.py
+++ b/office365/runtime/queries/update_entity_query.py
@@ -8,8 +8,8 @@ class UpdateEntityQuery(ClientQuery):
 
         :type entity_to_update: office365.runtime.client_object.ClientObject
         """
-        super(UpdateEntityQuery, self).__init__(entity_to_update.context,
-                                                entity_to_update,
-                                                entity_to_update,
-                                                None,
-                                                None)
+        super().__init__(entity_to_update.context,
+                         entity_to_update,
+                         entity_to_update,
+                         None,
+                         None)

--- a/office365/runtime/resource_path.py
+++ b/office365/runtime/resource_path.py
@@ -1,5 +1,5 @@
 
-class ResourcePath(object):
+class ResourcePath:
     """OData resource path"""
 
     def __init__(self, segment, parent=None):

--- a/office365/runtime/resource_path_service_operation.py
+++ b/office365/runtime/resource_path_service_operation.py
@@ -13,5 +13,4 @@ class ResourcePathServiceOperation(ResourcePath):
 
 
         """
-        super(ResourcePathServiceOperation, self).__init__(ODataPathParser.from_method(method_name, method_parameters),
-                                                           parent)
+        super().__init__(ODataPathParser.from_method(method_name, method_parameters), parent)

--- a/office365/sharepoint/actions/download_file.py
+++ b/office365/sharepoint/actions/download_file.py
@@ -23,5 +23,5 @@ class DownloadFileQuery(ServiceOperationQuery):
             """
             file_object.write(response.content)
 
-        super(DownloadFileQuery, self).__init__(web, r"getFileByServerRelativeUrl('{0}')/\$value".format(file_url))
+        super().__init__(web, r"getFileByServerRelativeUrl('{0}')/\$value".format(file_url))
         self.context.before_execute(_construct_download_query)

--- a/office365/sharepoint/actions/upload_file.py
+++ b/office365/sharepoint/actions/upload_file.py
@@ -27,4 +27,4 @@ class UploadFileQuery(ServiceOperationQuery):
 
         web.context.before_execute(_construct_upload_request)
         web.context.after_execute(_process_response)
-        super(UploadFileQuery, self).__init__(web, r"getFileByServerRelativeUrl('{0}')/\$value".format(file_url))
+        super().__init__(web, r"getFileByServerRelativeUrl('{0}')/\$value".format(file_url))

--- a/office365/sharepoint/attachments/attachmentfile.py
+++ b/office365/sharepoint/attachments/attachmentfile.py
@@ -56,7 +56,7 @@ class AttachmentFile(AbstractFile):
         return self._parent_collection
 
     def set_property(self, name, value, persist_changes=True):
-        super(AttachmentFile, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: create a new resource path
         if name == "ServerRelativeUrl":
             self._resource_path = ResourcePathServiceOperation(

--- a/office365/sharepoint/attachments/attachmentfile_collection.py
+++ b/office365/sharepoint/attachments/attachmentfile_collection.py
@@ -10,14 +10,14 @@ class AttachmentFileCollection(ClientObjectCollection):
     """Represents a collection of AttachmentFile resources."""
 
     def __init__(self, context, resource_path=None):
-        super(AttachmentFileCollection, self).__init__(context, AttachmentFile, resource_path)
+        super().__init__(context, AttachmentFile, resource_path)
 
     def get(self):
         """
 
         :rtype: AttachmentFileCollection
         """
-        return super(AttachmentFileCollection, self).get()
+        return super().get()
 
     def add(self, attachment_file_information):
         """

--- a/office365/sharepoint/attachments/attachmentfile_creation_information.py
+++ b/office365/sharepoint/attachments/attachmentfile_creation_information.py
@@ -10,7 +10,7 @@ class AttachmentfileCreationInformation(ClientValue):
         :type filename: str
         :type content: str or bytes
         """
-        super(AttachmentfileCreationInformation, self).__init__()
+        super().__init__()
         self._filename = filename
         self._content = content
 

--- a/office365/sharepoint/changes/change.py
+++ b/office365/sharepoint/changes/change.py
@@ -33,7 +33,7 @@ class Change(BaseEntity):
         return self.properties.get("SiteId", None)
 
     def set_property(self, name, value, persist_changes=True):
-        super(Change, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         #if name == "ChangeType":
         #    self.__class__ = self.resolve_change_type(value)
         return self

--- a/office365/sharepoint/changes/change_collection.py
+++ b/office365/sharepoint/changes/change_collection.py
@@ -5,4 +5,4 @@ from office365.sharepoint.changes.change import Change
 class ChangeCollection(ClientObjectCollection):
 
     def __init__(self, context, resource_path=None):
-        super(ChangeCollection, self).__init__(context, Change, resource_path)
+        super().__init__(context, Change, resource_path)

--- a/office365/sharepoint/client_context.py
+++ b/office365/sharepoint/client_context.py
@@ -41,7 +41,7 @@ class ClientContext(ClientRuntimeContext):
         """
         if base_url.endswith("/"):
             base_url = base_url[:len(base_url) - 1]
-        super(ClientContext, self).__init__(auth_context)
+        super().__init__(auth_context)
         self.__web = None
         self.__site = None
         self._base_url = base_url
@@ -140,7 +140,7 @@ class ClientContext(ClientRuntimeContext):
         batch_request.execute_query()
 
     def build_request(self):
-        request = super(ClientContext, self).build_request()
+        request = super().build_request()
         self._build_modification_query(request)
         return request
 

--- a/office365/sharepoint/contenttypes/content_type.py
+++ b/office365/sharepoint/contenttypes/content_type.py
@@ -82,7 +82,7 @@ class ContentType(BaseEntity):
             return ContentType(self.context, ResourcePath("Parent", self.resource_path))
 
     def set_property(self, name, value, persist_changes=True):
-        super(ContentType, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: create a new resource path
         if name == "StringId" and self._resource_path is None:
             self._resource_path = ResourcePathServiceOperation(

--- a/office365/sharepoint/contenttypes/content_type_collection.py
+++ b/office365/sharepoint/contenttypes/content_type_collection.py
@@ -8,7 +8,7 @@ class ContentTypeCollection(ClientObjectCollection):
     """Content Type resource collection"""
 
     def __init__(self, context, resource_path=None):
-        super(ContentTypeCollection, self).__init__(context, ContentType, resource_path)
+        super().__init__(context, ContentType, resource_path)
 
     def get_by_id(self, contentTypeId):
         """

--- a/office365/sharepoint/directory/directorySession.py
+++ b/office365/sharepoint/directory/directorySession.py
@@ -6,7 +6,7 @@ from office365.sharepoint.directory.user import User
 
 class DirectorySession(BaseEntity):
     def __init__(self, context):
-        super(DirectorySession, self).__init__(context, ResourcePath("SP.Directory.DirectorySession"))
+        super().__init__(context, ResourcePath("SP.Directory.DirectorySession"))
 
     def me(self):
         """Create a modern site"""

--- a/office365/sharepoint/fields/field.py
+++ b/office365/sharepoint/fields/field.py
@@ -81,7 +81,7 @@ class Field(BaseEntity):
         return self.properties.get('InternalName', None)
 
     def set_property(self, name, value, persist_changes=True):
-        super(Field, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: create a new resource path
         if name == "Id" and self._resource_path is None:
             self._resource_path = ResourcePathServiceOperation(

--- a/office365/sharepoint/fields/field_collection.py
+++ b/office365/sharepoint/fields/field_collection.py
@@ -8,10 +8,10 @@ class FieldCollection(ClientObjectCollection):
     """Represents a collection of Field resource."""
 
     def __init__(self, context, resource_path=None):
-        super(FieldCollection, self).__init__(context, Field, resource_path)
+        super().__init__(context, Field, resource_path)
 
     def create_typed_object(self, properties):
-        field = super(FieldCollection, self).create_typed_object(properties)
+        field = super().create_typed_object(properties)
         return field
 
     def add(self, field_create_information):

--- a/office365/sharepoint/fields/field_creation_information.py
+++ b/office365/sharepoint/fields/field_creation_information.py
@@ -12,7 +12,7 @@ class FieldCreationInformation(ClientValue):
 
         :type title: str
         """
-        super(FieldCreationInformation, self).__init__()
+        super().__init__()
         self.Title = title
         self.FieldTypeKind = field_type_kind
         self.Description = description

--- a/office365/sharepoint/fields/related_field_collection.py
+++ b/office365/sharepoint/fields/related_field_collection.py
@@ -5,4 +5,4 @@ from office365.sharepoint.fields.related_field import RelatedField
 class RelatedFieldCollection(ClientObjectCollection):
 
     def __init__(self, context, resource_path=None):
-        super(RelatedFieldCollection, self).__init__(context, RelatedField, resource_path)
+        super().__init__(context, RelatedField, resource_path)

--- a/office365/sharepoint/files/checkedOutFileCollection.py
+++ b/office365/sharepoint/files/checkedOutFileCollection.py
@@ -4,4 +4,4 @@ from office365.sharepoint.files.checkedOutFile import CheckedOutFile
 
 class CheckedOutFileCollection(ClientObjectCollection):
     def __init__(self, context, resource_path=None):
-        super(CheckedOutFileCollection, self).__init__(context, CheckedOutFile, resource_path)
+        super().__init__(context, CheckedOutFile, resource_path)

--- a/office365/sharepoint/files/file.py
+++ b/office365/sharepoint/files/file.py
@@ -366,7 +366,7 @@ class File(AbstractFile):
         return self.properties.get("TimeLastModified", None)
 
     def set_property(self, name, value, persist_changes=True):
-        super(File, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: create a new resource path
         if self._resource_path is None:
             if name == "ServerRelativeUrl":

--- a/office365/sharepoint/files/file_collection.py
+++ b/office365/sharepoint/files/file_collection.py
@@ -10,14 +10,14 @@ class FileCollection(ClientObjectCollection):
     """Represents a collection of File resources."""
 
     def __init__(self, context, resource_path=None):
-        super(FileCollection, self).__init__(context, File, resource_path)
+        super().__init__(context, File, resource_path)
 
     def get(self):
         """
 
         :rtype: FileCollection
         """
-        return super(FileCollection, self).get()
+        return super().get()
 
     def create_upload_session(self, source_path, chunk_size, chunk_uploaded=None):
         """Upload a file as multiple chunks

--- a/office365/sharepoint/files/file_creation_information.py
+++ b/office365/sharepoint/files/file_creation_information.py
@@ -9,7 +9,7 @@ class FileCreationInformation(ClientValue):
 
         :type url: str
         """
-        super(FileCreationInformation, self).__init__()
+        super().__init__()
         self._url = url
         self._overwrite = overwrite
         self._content = content

--- a/office365/sharepoint/files/file_version_collection.py
+++ b/office365/sharepoint/files/file_version_collection.py
@@ -5,4 +5,4 @@ from office365.sharepoint.files.file_version import FileVersion
 class FileVersionCollection(ClientObjectCollection):
     """Represents a collection of FileVersion."""
     def __init__(self, context, resource_path=None):
-        super(FileVersionCollection, self).__init__(context, FileVersion, resource_path)
+        super().__init__(context, FileVersion, resource_path)

--- a/office365/sharepoint/folders/folder.py
+++ b/office365/sharepoint/folders/folder.py
@@ -145,7 +145,7 @@ class Folder(BaseEntity):
             return FolderCollection(self.context, ResourcePath("Folders", self.resource_path))
 
     def set_property(self, name, value, persist_changes=True):
-        super(Folder, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: create a new resource path
         if self._resource_path is None:
             if name == "ServerRelativeUrl":

--- a/office365/sharepoint/folders/folder_collection.py
+++ b/office365/sharepoint/folders/folder_collection.py
@@ -7,7 +7,7 @@ from office365.sharepoint.folders.folder import Folder
 class FolderCollection(ClientObjectCollection):
     """Represents a collection of Folder resources."""
     def __init__(self, context, resource_path=None):
-        super(FolderCollection, self).__init__(context, Folder, resource_path)
+        super().__init__(context, Folder, resource_path)
 
     def add(self, server_relative_url):
         """Adds the folder that is located at the specified URL to the collection.

--- a/office365/sharepoint/forms/formCollection.py
+++ b/office365/sharepoint/forms/formCollection.py
@@ -5,7 +5,7 @@ from office365.sharepoint.forms.form import Form
 class FormCollection(ClientObjectCollection):
 
     def __init__(self, context, resource_path=None):
-        super(FormCollection, self).__init__(context, Form, resource_path)
+        super().__init__(context, Form, resource_path)
 
     def get_by_page_type(self):
         pass

--- a/office365/sharepoint/listdatasvc/list_data_service.py
+++ b/office365/sharepoint/listdatasvc/list_data_service.py
@@ -19,7 +19,7 @@ class ListDataService(ClientRuntimeContext):
         if base_url.endswith("/"):
             base_url = base_url[:len(base_url) - 1]
         self._base_url = base_url
-        super(ListDataService, self).__init__(auth_context)
+        super().__init__(auth_context)
         self._pendingRequest = ODataRequest(self, JsonLightFormat(ODataMetadataLevel.Verbose))
 
     @classmethod

--- a/office365/sharepoint/listitems/caml/camlQuery.py
+++ b/office365/sharepoint/listitems/caml/camlQuery.py
@@ -17,7 +17,7 @@ class CamlQuery(ClientValue):
             results are to be returned.
         :param bool datesInUtc: Specifies whether the query returns dates in Coordinated Universal Time (UTC) format.
         """
-        super(CamlQuery, self).__init__()
+        super().__init__()
         self.DatesInUtc = datesInUtc
         self.FolderServerRelativeUrl = folderServerRelativeUrl
         self.AllowIncrementalResults = allowIncrementalResults

--- a/office365/sharepoint/listitems/listItem_collection.py
+++ b/office365/sharepoint/listitems/listItem_collection.py
@@ -5,4 +5,4 @@ from office365.sharepoint.listitems.listitem import ListItem
 class ListItemCollection(ClientObjectCollection):
     """List Item collection"""
     def __init__(self, context, resource_path=None):
-        super(ListItemCollection, self).__init__(context, ListItem, resource_path)
+        super().__init__(context, ListItem, resource_path)

--- a/office365/sharepoint/listitems/listitem.py
+++ b/office365/sharepoint/listitems/listitem.py
@@ -231,7 +231,7 @@ class ListItem(SecurableObject):
         return self.properties.get("CommentsDisabled", None)
 
     def set_property(self, name, value, persist_changes=True):
-        super(ListItem, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: create a new resource path
         if self._resource_path is None:
             if name == "Id" and self._parent_collection is not None:

--- a/office365/sharepoint/lists/list.py
+++ b/office365/sharepoint/lists/list.py
@@ -23,7 +23,7 @@ class List(SecurableObject):
     """List resource"""
 
     def __init__(self, context, resource_path=None):
-        super(List, self).__init__(context, resource_path)
+        super().__init__(context, resource_path)
 
     def save_as_template(self, fileName, name, description, saveData):
         """
@@ -260,7 +260,7 @@ class List(SecurableObject):
         self.set_property('Description', val)
 
     def set_property(self, name, value, persist_changes=True):
-        super(List, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: create a new resource path
         if self._resource_path is None:
             if name == "Id":

--- a/office365/sharepoint/lists/list_collection.py
+++ b/office365/sharepoint/lists/list_collection.py
@@ -9,7 +9,7 @@ class ListCollection(ClientObjectCollection):
     """Lists collection"""
 
     def __init__(self, context, resource_path=None):
-        super(ListCollection, self).__init__(context, List, resource_path)
+        super().__init__(context, List, resource_path)
 
     def get_by_title(self, list_title):
         """Retrieve List client object by title

--- a/office365/sharepoint/lists/list_creation_information.py
+++ b/office365/sharepoint/lists/list_creation_information.py
@@ -12,7 +12,7 @@ class ListCreationInformation(ClientValue):
         :type description: str or None
         :type title: str
         """
-        super(ListCreationInformation, self).__init__()
+        super().__init__()
         self.Title = title
         self.Description = description
         self.BaseTemplate = base_template

--- a/office365/sharepoint/permissions/basePermissions.py
+++ b/office365/sharepoint/permissions/basePermissions.py
@@ -8,7 +8,7 @@ class BasePermissions(ClientValue):
     """Specifies a set of built-in permissions."""
 
     def __init__(self):
-        super(BasePermissions, self).__init__()
+        super().__init__()
         self.High = 0
         self.Low = 0
 

--- a/office365/sharepoint/permissions/roleAssignmentCollection.py
+++ b/office365/sharepoint/permissions/roleAssignmentCollection.py
@@ -9,14 +9,14 @@ class RoleAssignmentCollection(ClientObjectCollection):
     """Represents a collection of RoleAssignment resources."""
 
     def __init__(self, context, resource_path=None):
-        super(RoleAssignmentCollection, self).__init__(context, RoleAssignment, resource_path)
+        super().__init__(context, RoleAssignment, resource_path)
 
     def __getitem__(self, index_or_principal_id):
         """
         :param int or str index_or_principal_id: key is used to address a RoleAssignment resource by either an index
         in collection or by resource id"""
         if type(index_or_principal_id) == int:
-            return super(RoleAssignmentCollection, self).__getitem__(index_or_principal_id)
+            return super().__getitem__(index_or_principal_id)
         return self._item_type(self.context,
                                ResourcePath(index_or_principal_id, self.resource_path))
 

--- a/office365/sharepoint/permissions/roleDefinitionCollection.py
+++ b/office365/sharepoint/permissions/roleDefinitionCollection.py
@@ -6,7 +6,7 @@ from office365.sharepoint.permissions.roleDefinition import RoleDefinition
 class RoleDefinitionCollection(ClientObjectCollection):
 
     def __init__(self, context, resource_path=None):
-        super(RoleDefinitionCollection, self).__init__(context, RoleDefinition, resource_path)
+        super().__init__(context, RoleDefinition, resource_path)
 
     def get_by_type(self, role_type):
         """Returns role definition of the specified type from the collection.

--- a/office365/sharepoint/permissions/roleDefinitionCreationInformation.py
+++ b/office365/sharepoint/permissions/roleDefinitionCreationInformation.py
@@ -6,7 +6,7 @@ class RoleDefinitionCreationInformation(ClientValue):
 
     def __init__(self):
         """Contains properties that are used as parameters to initialize a role definition."""
-        super(RoleDefinitionCreationInformation, self).__init__()
+        super().__init__()
         self.Name = None
         self.Description = None
         self.BasePermissions = BasePermissions()

--- a/office365/sharepoint/portal/GroupSiteInfo.py
+++ b/office365/sharepoint/portal/GroupSiteInfo.py
@@ -4,7 +4,7 @@ from office365.runtime.client_value import ClientValue
 class GroupSiteInfo(ClientValue):
 
     def __init__(self):
-        super(GroupSiteInfo, self).__init__()
+        super().__init__()
         self.SiteStatus = None
         self.SiteUrl = None
         self.DocumentsUrl = None

--- a/office365/sharepoint/portal/GroupSiteManager.py
+++ b/office365/sharepoint/portal/GroupSiteManager.py
@@ -7,7 +7,7 @@ from office365.sharepoint.portal.GroupSiteInfo import GroupSiteInfo
 
 class GroupSiteManager(ClientObject):
     def __init__(self, context):
-        super(GroupSiteManager, self).__init__(context, ResourcePath("GroupSiteManager"), None)
+        super().__init__(context, ResourcePath("GroupSiteManager"), None)
 
     def create_group_ex(self, display_name, alias, is_public, optional_params):
         """

--- a/office365/sharepoint/portal/SPSiteCreationResponse.py
+++ b/office365/sharepoint/portal/SPSiteCreationResponse.py
@@ -4,7 +4,7 @@ from office365.runtime.client_value import ClientValue
 class SPSiteCreationResponse(ClientValue):
 
     def __init__(self):
-        super(SPSiteCreationResponse, self).__init__()
+        super().__init__()
         self.SiteId = None
         self.SiteStatus = None
         self.SiteUrl = None

--- a/office365/sharepoint/portal/SPSiteManager.py
+++ b/office365/sharepoint/portal/SPSiteManager.py
@@ -8,7 +8,7 @@ from office365.sharepoint.portal.SPSiteCreationResponse import SPSiteCreationRes
 class SPSiteManager(BaseEntity):
 
     def __init__(self, context):
-        super(SPSiteManager, self).__init__(context, ResourcePath("SPSiteManager"))
+        super().__init__(context, ResourcePath("SPSiteManager"))
 
     def create(self, request):
         """Create a modern site"""

--- a/office365/sharepoint/principal/group_collection.py
+++ b/office365/sharepoint/principal/group_collection.py
@@ -8,7 +8,7 @@ from office365.sharepoint.principal.group import Group
 class GroupCollection(ClientObjectCollection):
     """Represents a collection of Group resources."""
     def __init__(self, context, resource_path=None):
-        super(GroupCollection, self).__init__(context, Group, resource_path)
+        super().__init__(context, Group, resource_path)
 
     def add(self, group_creation_information):
         """Creates a Group resource"""

--- a/office365/sharepoint/principal/principal.py
+++ b/office365/sharepoint/principal/principal.py
@@ -58,7 +58,7 @@ class Principal(BaseEntity):
         return self.properties.get('PrincipalType', None)
 
     def set_property(self, name, value, persist_changes=True):
-        super(Principal, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: create a new resource path
         if self._resource_path is None:
             if name == "Id":

--- a/office365/sharepoint/principal/roleDefinitionCreationInformation.py
+++ b/office365/sharepoint/principal/roleDefinitionCreationInformation.py
@@ -6,7 +6,7 @@ class RoleDefinitionCreationInformation(ClientValue):
 
     def __init__(self):
         """Contains properties that are used as parameters to initialize a role definition."""
-        super(RoleDefinitionCreationInformation, self).__init__()
+        super().__init__()
         self.Name = None
         self.Description = None
         self.BasePermissions = BasePermissions()

--- a/office365/sharepoint/principal/user.py
+++ b/office365/sharepoint/principal/user.py
@@ -8,7 +8,7 @@ class User(Principal):
     """Represents a user in Microsoft SharePoint Foundation. A user is a type of SP.Principal."""
 
     def get(self):
-        return super(User, self).get()
+        return super().get()
 
     @property
     def groups(self):

--- a/office365/sharepoint/principal/userIdInfo.py
+++ b/office365/sharepoint/principal/userIdInfo.py
@@ -5,6 +5,6 @@ class UserIdInfo(ClientValue):
 
     def __init__(self):
         """Represents an identity provider’s unique identifier information."""
-        super(UserIdInfo, self).__init__()
+        super().__init__()
         self.NameId = None
         self.NameIdIssuer = None

--- a/office365/sharepoint/principal/user_collection.py
+++ b/office365/sharepoint/principal/user_collection.py
@@ -9,7 +9,7 @@ class UserCollection(ClientObjectCollection):
     """Represents a collection of User resources."""
 
     def __init__(self, context, resource_path=None):
-        super(UserCollection, self).__init__(context, User, resource_path)
+        super().__init__(context, User, resource_path)
 
     def add_user(self, login_name):
         """

--- a/office365/sharepoint/recyclebin/recycleBinItem.py
+++ b/office365/sharepoint/recyclebin/recycleBinItem.py
@@ -42,7 +42,7 @@ class RecycleBinItem(BaseEntity):
         return self.properties.get('DeletedDate', None)
 
     def set_property(self, name, value, persist_changes=True):
-        super(RecycleBinItem, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: create a new resource path
         if self._resource_path is None:
             if name == "Id" and self._parent_collection is not None:

--- a/office365/sharepoint/recyclebin/recycleBinItemCollection.py
+++ b/office365/sharepoint/recyclebin/recycleBinItemCollection.py
@@ -8,7 +8,7 @@ class RecycleBinItemCollection(ClientObjectCollection):
     """Represents a collection of View resources."""
 
     def __init__(self, context, resource_path=None):
-        super(RecycleBinItemCollection, self).__init__(context, RecycleBinItem, resource_path)
+        super().__init__(context, RecycleBinItem, resource_path)
 
     def move_all_to_second_stage(self):
         qry = ServiceOperationQuery(self, "MoveAllToSecondStage")

--- a/office365/sharepoint/sites/site.py
+++ b/office365/sharepoint/sites/site.py
@@ -14,7 +14,7 @@ class Site(ClientObject):
     """Represents a collection of sites in a Web application, including a top-level website and all its subsites."""
 
     def __init__(self, context):
-        super(Site, self).__init__(context, ResourcePath("Site", None))
+        super().__init__(context, ResourcePath("Site", None))
 
     def get_changes(self, query):
         """Returns the collection of all changes from the change log that have occurred within the scope of the site,

--- a/office365/sharepoint/tenant/administration/siteProperties.py
+++ b/office365/sharepoint/tenant/administration/siteProperties.py
@@ -7,7 +7,7 @@ class SiteProperties(BaseEntity):
         super().__init__(context)
 
     def set_property(self, name, value, persist_changes=True):
-        super(SiteProperties, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: create a new resource path
         if name == "Url" and self._resource_path is None:
             pass

--- a/office365/sharepoint/tenant/administration/sitePropertiesCollection.py
+++ b/office365/sharepoint/tenant/administration/sitePropertiesCollection.py
@@ -6,7 +6,7 @@ from office365.sharepoint.tenant.administration.siteProperties import SiteProper
 class SitePropertiesCollection(ClientObjectCollection):
     """CSiteProperties resource collection"""
     def __init__(self, context, resource_path=None):
-        super(SitePropertiesCollection, self).__init__(context, SiteProperties, resource_path)
+        super().__init__(context, SiteProperties, resource_path)
 
     def get_by_id(self, site_id):
         site_props = SiteProperties(self.context)

--- a/office365/sharepoint/views/view.py
+++ b/office365/sharepoint/views/view.py
@@ -12,7 +12,7 @@ class View(BaseEntity):
     """Specifies a list view."""
 
     def __init__(self, context, resource_path=None, parent_list=None):
-        super(View, self).__init__(context, resource_path)
+        super().__init__(context, resource_path)
         self._parent_list = parent_list
 
     def get_items(self):
@@ -92,7 +92,7 @@ class View(BaseEntity):
             return None
 
     def set_property(self, name, value, persist_changes=True):
-        super(View, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: create a new resource path
         if self._resource_path is None:
             if name == "Id":

--- a/office365/sharepoint/views/view_collection.py
+++ b/office365/sharepoint/views/view_collection.py
@@ -12,7 +12,7 @@ class ViewCollection(ClientObjectCollection):
 
         :type parent_list: office365.sharepoint.list.List or None
         """
-        super(ViewCollection, self).__init__(context, View, resource_path)
+        super().__init__(context, View, resource_path)
         self._parent_list = parent_list
 
     def add(self, view_creation_information):

--- a/office365/sharepoint/views/view_create_information.py
+++ b/office365/sharepoint/views/view_create_information.py
@@ -5,7 +5,7 @@ class ViewCreationInformation(ClientValue):
     """Specifies the properties used to create a new list view."""
 
     def __init__(self):
-        super(ViewCreationInformation, self).__init__()
+        super().__init__()
         self.Title = None
         self.ViewTypeKind = None
         self.ViewFields = None

--- a/office365/sharepoint/views/view_field_collection.py
+++ b/office365/sharepoint/views/view_field_collection.py
@@ -5,4 +5,4 @@ from office365.sharepoint.fields.field import Field
 class ViewFieldCollection(ClientObjectCollection):
     """Represents a collection of Field resources."""
     def __init__(self, context, resource_path=None):
-        super(ViewFieldCollection, self).__init__(context, Field, resource_path)
+        super().__init__(context, Field, resource_path)

--- a/office365/sharepoint/webs/context_web_information.py
+++ b/office365/sharepoint/webs/context_web_information.py
@@ -5,7 +5,7 @@ class ContextWebInformation(ClientValue):
     """The context information for a site."""
 
     def __init__(self):
-        super(ContextWebInformation, self).__init__()
+        super().__init__()
         self.FormDigestValue = None
         self.FormDigestTimeoutSeconds = None
         self.LibraryVersion = None

--- a/office365/sharepoint/webs/subweb_query.py
+++ b/office365/sharepoint/webs/subweb_query.py
@@ -5,7 +5,7 @@ class SubwebQuery(ClientValue):
     """Defines a query to specify which child Web sites to return from a Web site."""
 
     def __init__(self, configuration_filter=-1, web_template_filter=-1):
-        super(SubwebQuery, self).__init__()
+        super().__init__()
         """Specifies the site definition."""
         self.WebTemplateFilter = web_template_filter
         """ A 16-bit integer that specifies the identifier of a configuration"""

--- a/office365/sharepoint/webs/web.py
+++ b/office365/sharepoint/webs/web.py
@@ -47,7 +47,7 @@ class Web(SecurableObject):
         """
         if resource_path is None:
             resource_path = ResourcePath("Web")
-        super(Web, self).__init__(context, resource_path)
+        super().__init__(context, resource_path)
         self._web_url = None
 
     @staticmethod
@@ -584,7 +584,7 @@ class Web(SecurableObject):
                                                             ResourcePath("RecycleBin", self.resource_path)))
 
     def set_property(self, name, value, persist_changes=True):
-        super(Web, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: create a new resource path
         if name == "Url":
             self._web_url = value
@@ -592,7 +592,7 @@ class Web(SecurableObject):
 
     @property
     def resource_url(self):
-        url = super(Web, self).resource_url
+        url = super().resource_url
         if self._web_url is not None:
             url = url.replace(self.context.service_root_url(), self._web_url + '/_api/')
         return url

--- a/office365/sharepoint/webs/web_collection.py
+++ b/office365/sharepoint/webs/web_collection.py
@@ -7,7 +7,7 @@ class WebCollection(ClientObjectCollection):
     """Web collection"""
 
     def __init__(self, context, resource_path=None, parent_web_url=None):
-        super(WebCollection, self).__init__(context, Web, resource_path)
+        super().__init__(context, Web, resource_path)
         self._parent_web_url = parent_web_url
 
     def add(self, web_creation_information):
@@ -19,7 +19,7 @@ class WebCollection(ClientObjectCollection):
 
     @property
     def resource_url(self):
-        url = super(WebCollection, self).resource_url
+        url = super().resource_url
         if self._parent_web_url is not None:
             url = url.replace(self.context.service_root_url(), self._parent_web_url + '/_api/')
         return url

--- a/office365/sharepoint/webs/web_creation_information.py
+++ b/office365/sharepoint/webs/web_creation_information.py
@@ -5,7 +5,7 @@ class WebCreationInformation(ClientValue):
     """Represents metadata about site creation."""
 
     def __init__(self):
-        super(WebCreationInformation, self).__init__()
+        super().__init__()
         self.Title = None
         self.Url = None
 

--- a/office365/teams/channel.py
+++ b/office365/teams/channel.py
@@ -39,7 +39,7 @@ class Channel(Entity):
         return self.properties.get('webUrl', None)
 
     def set_property(self, name, value, persist_changes=True):
-        super(Channel, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: fix resource path
         if name == "id":
             channel_id = quote(value)

--- a/office365/teams/channelCollection.py
+++ b/office365/teams/channelCollection.py
@@ -8,7 +8,7 @@ class ChannelCollection(ClientObjectCollection):
     """Team's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(ChannelCollection, self).__init__(context, Channel, resource_path)
+        super().__init__(context, Channel, resource_path)
 
     def __getitem__(self, key):
         if type(key) == int:

--- a/office365/teams/chatMessageCollection.py
+++ b/office365/teams/chatMessageCollection.py
@@ -6,7 +6,7 @@ from office365.teams.chatMessage import ChatMessage
 class ChatMessageCollection(ClientObjectCollection):
 
     def __init__(self, context, resource_path=None):
-        super(ChatMessageCollection, self).__init__(context, ChatMessage, resource_path)
+        super().__init__(context, ChatMessage, resource_path)
 
     def add(self, item_body):
         """Create a new chatMessage in the specified channel.

--- a/office365/teams/participantCollection.py
+++ b/office365/teams/participantCollection.py
@@ -5,4 +5,4 @@ from office365.teams.participant import Participant
 class ParticipantCollection(ClientObjectCollection):
 
     def __init__(self, context, resource_path=None):
-        super(ParticipantCollection, self).__init__(context, Participant, resource_path)
+        super().__init__(context, Participant, resource_path)

--- a/office365/teams/team.py
+++ b/office365/teams/team.py
@@ -84,7 +84,7 @@ class Team(Entity):
         return self
 
     def set_property(self, name, value, persist_changes=True):
-        super(Team, self).set_property(name, value, persist_changes)
+        super().set_property(name, value, persist_changes)
         # fallback: fix resource path
         if name == "id" and self._resource_path.segment == "team":
             self._resource_path = ResourcePath(value, ResourcePath("teams"))

--- a/office365/teams/teamCollection.py
+++ b/office365/teams/teamCollection.py
@@ -9,7 +9,7 @@ class TeamCollection(EntityCollection):
     """Team's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(TeamCollection, self).__init__(context, Team, resource_path)
+        super().__init__(context, Team, resource_path)
 
     def __getitem__(self, key):
         if type(key) == int:

--- a/office365/teams/teamsAppInstallationCollection.py
+++ b/office365/teams/teamsAppInstallationCollection.py
@@ -5,4 +5,4 @@ from office365.teams.teamsAppInstallation import TeamsAppInstallation
 class TeamsAppInstallationCollection(ClientObjectCollection):
 
     def __init__(self, context, resource_path=None):
-        super(TeamsAppInstallationCollection, self).__init__(context, TeamsAppInstallation, resource_path)
+        super().__init__(context, TeamsAppInstallation, resource_path)

--- a/office365/teams/teamsAsyncOperationCollection.py
+++ b/office365/teams/teamsAsyncOperationCollection.py
@@ -6,4 +6,4 @@ class TeamsAsyncOperationCollection(ClientObjectCollection):
     """TeamsAsyncOperation's collection"""
 
     def __init__(self, context, resource_path=None):
-        super(TeamsAsyncOperationCollection, self).__init__(context, TeamsAsyncOperation, resource_path)
+        super().__init__(context, TeamsAsyncOperation, resource_path)

--- a/office365/teams/teamsTabCollection.py
+++ b/office365/teams/teamsTabCollection.py
@@ -5,4 +5,4 @@ from office365.teams.teamsTab import TeamsTab
 class TeamsTabCollection(ClientObjectCollection):
 
     def __init__(self, context, resource_path=None):
-        super(TeamsTabCollection, self).__init__(context, TeamsTab, resource_path)
+        super().__init__(context, TeamsTab, resource_path)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import io
 from distutils.core import setup
 
@@ -19,6 +18,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/vgrem/Office365-REST-Python-Client",
+    python_requires=">=3.6",
     install_requires=['requests', 'adal'],
     extras_require={
         'NTLMAuthentication': ["requests_ntlm"]
@@ -34,10 +34,7 @@ setup(
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Software Development :: Libraries",
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tests/onedrive/test_driveItem.py
+++ b/tests/onedrive/test_driveItem.py
@@ -24,7 +24,7 @@ class TestDriveItem(GraphTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestDriveItem, cls).setUpClass()
+        super().setUpClass()
         cls.target_drive = create_list_drive(cls.client)
 
     @classmethod

--- a/tests/onedrive/test_permissions.py
+++ b/tests/onedrive/test_permissions.py
@@ -11,7 +11,7 @@ class TestPermissions(GraphTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestPermissions, cls).setUpClass()
+        super().setUpClass()
         folder_name = "New_" + uuid.uuid4().hex
         cls.target_drive_item = cls.client.sites.root.drive.root.create_folder(folder_name).execute_query()
 

--- a/tests/sharepoint/test_attachment.py
+++ b/tests/sharepoint/test_attachment.py
@@ -17,7 +17,7 @@ class TestListItemAttachment(SPTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestListItemAttachment, cls).setUpClass()
+        super().setUpClass()
         list_name = "Tasks" + str(randint(0, 10000))
         cls.target_list = cls.ensure_list(cls.client.web,
                                           ListCreationInformation(list_name,

--- a/tests/sharepoint/test_comminication_site.py
+++ b/tests/sharepoint/test_comminication_site.py
@@ -15,7 +15,7 @@ class TestCommunicationSite(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestCommunicationSite, cls).setUpClass()
+        super().setUpClass()
         ctx_auth = AuthenticationContext(url=settings['url'])
         ctx_auth.acquire_token_for_user(username=settings['user_credentials']['username'],
                                         password=settings['user_credentials']['password'])

--- a/tests/sharepoint/test_directory_session.py
+++ b/tests/sharepoint/test_directory_session.py
@@ -12,7 +12,7 @@ class TestDirectorySession(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestDirectorySession, cls).setUpClass()
+        super().setUpClass()
 
         user_credentials = UserCredential(settings['user_credentials']['username'],
                                           settings['user_credentials']['password'])

--- a/tests/sharepoint/test_field_value.py
+++ b/tests/sharepoint/test_field_value.py
@@ -22,7 +22,7 @@ class TestFieldValue(SPTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestFieldValue, cls).setUpClass()
+        super().setUpClass()
         cls.target_list = cls.ensure_list(cls.client.web,
                                           ListCreationInformation(
                                               "Tasks N%s" % random_seed,

--- a/tests/sharepoint/test_file.py
+++ b/tests/sharepoint/test_file.py
@@ -30,7 +30,7 @@ class TestSharePointFile(SPTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestSharePointFile, cls).setUpClass()
+        super().setUpClass()
         cls.target_list = cls.ensure_list(cls.client.web,
                                           ListCreationInformation(
                                               "Archive Documents N%s" % random_seed,

--- a/tests/sharepoint/test_folder.py
+++ b/tests/sharepoint/test_folder.py
@@ -20,7 +20,7 @@ class TestSharePointFolder(SPTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestSharePointFolder, cls).setUpClass()
+        super().setUpClass()
         cls.target_list = cls.ensure_list(cls.client.web,
                                           ListCreationInformation(
                                               "Documents %s" % random_seed,

--- a/tests/sharepoint/test_group.py
+++ b/tests/sharepoint/test_group.py
@@ -8,7 +8,7 @@ class TestSharePointGroup(SPTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestSharePointGroup, cls).setUpClass()
+        super().setUpClass()
         cls.target_user_name = "i:0#.f|membership|mdoe@mediadev8.onmicrosoft.com"
         cls.target_group = cls.client.web.associatedMemberGroup
 

--- a/tests/sharepoint/test_listItem.py
+++ b/tests/sharepoint/test_listItem.py
@@ -17,7 +17,7 @@ class TestSharePointListItem(SPTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestSharePointListItem, cls).setUpClass()
+        super().setUpClass()
         target_list_title = "Tasks" + str(randint(0, 10000))
         cls.target_list = cls.ensure_list(cls.client.web,
                                           ListCreationInformation(target_list_title,

--- a/tests/sharepoint/test_listdataservice.py
+++ b/tests/sharepoint/test_listdataservice.py
@@ -10,7 +10,7 @@ class TestSharePointListDataService(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestSharePointListDataService, cls).setUpClass()
+        super().setUpClass()
         credential = ClientCredential(settings['client_credentials']['client_id'],
                                       settings['client_credentials']['client_secret'])
         cls.client = ListDataService.connect_with_credentials(settings['url'], credential)

--- a/tests/sharepoint/test_recycle_bin.py
+++ b/tests/sharepoint/test_recycle_bin.py
@@ -10,7 +10,7 @@ class TestSharePointRecycleBin(SPTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestSharePointRecycleBin, cls).setUpClass()
+        super().setUpClass()
         file_name = "Sample{0}.txt".format(str(randint(0, 10000)))
         target_file = cls.client.web.default_document_library().rootFolder \
             .upload_file(file_name, "--some content goes here--").execute_query()

--- a/tests/sharepoint/test_search.py
+++ b/tests/sharepoint/test_search.py
@@ -16,7 +16,7 @@ class TestSearch(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestSearch, cls).setUpClass()
+        super().setUpClass()
         user_credentials = UserCredential(settings['user_credentials']['username'],
                                           settings['user_credentials']['password'])
         cls.client = ClientContext(settings['url']).with_credentials(user_credentials)

--- a/tests/sharepoint/test_team_site.py
+++ b/tests/sharepoint/test_team_site.py
@@ -15,7 +15,7 @@ class TestTeamSite(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestTeamSite, cls).setUpClass()
+        super().setUpClass()
 
         user_credentials = UserCredential(settings['user_credentials']['username'],
                                           settings['user_credentials']['password'])

--- a/tests/sharepoint/test_view.py
+++ b/tests/sharepoint/test_view.py
@@ -15,7 +15,7 @@ class TestSPView(SPTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestSPView, cls).setUpClass()
+        super().setUpClass()
         cls.target_list = cls.ensure_list(cls.client.web,
                                           ListCreationInformation("Tasks",
                                                                   None,

--- a/tests/sharepoint/test_web.py
+++ b/tests/sharepoint/test_web.py
@@ -18,7 +18,7 @@ class TestSharePointWeb(SPTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestSharePointWeb, cls).setUpClass()
+        super().setUpClass()
 
     def test1_get_current_user(self):
         current_user = self.client.web.currentUser.get().execute_query()

--- a/tests/teams/test_apps.py
+++ b/tests/teams/test_apps.py
@@ -11,7 +11,7 @@ class TestTeamApps(GraphTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestTeamApps, cls).setUpClass()
+        super().setUpClass()
         team_name = "Team_" + uuid.uuid4().hex
         result = cls.client.teams.create(team_name)
         cls.client.execute_query_retry()

--- a/tests/teams/test_channel.py
+++ b/tests/teams/test_channel.py
@@ -18,7 +18,7 @@ class TestGraphChannel(GraphTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestGraphChannel, cls).setUpClass()
+        super().setUpClass()
         grp_name = "Group_" + uuid.uuid4().hex
         result = cls.client.teams.create(grp_name)
         cls.client.execute_query_retry()

--- a/tests/teams/test_team.py
+++ b/tests/teams/test_team.py
@@ -13,7 +13,7 @@ class TestGraphTeam(GraphTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestGraphTeam, cls).setUpClass()
+        super().setUpClass()
         grp_name = "Group_" + uuid.uuid4().hex
         properties = GroupProfile(grp_name)
         properties.securityEnabled = False


### PR DESCRIPTION
@vgrem with this PR I just want to exclude from ci python2.7 and python3.5.
Only changes made are:
- new syntax for super (removed class name and self)
- new syntax for base class (removed object)