### PR TITLE
Correctly support weird characters in filenames when downloading

### DIFF
--- a/office365/sharepoint/actions/download_file.py
+++ b/office365/sharepoint/actions/download_file.py
@@ -1,4 +1,5 @@
 from office365.runtime.http.http_method import HttpMethod
+from office365.runtime.odata.odata_path_parser import ODataPathParser
 from office365.runtime.queries.service_operation_query import ServiceOperationQuery
 
 
@@ -23,5 +24,9 @@ class DownloadFileQuery(ServiceOperationQuery):
             """
             file_object.write(response.content)
 
-        super(DownloadFileQuery, self).__init__(web, r"getFileByServerRelativeUrl('{0}')/\$value".format(file_url))
+        # Sharepoint Endpoint bug: https://github.com/SharePoint/sp-dev-docs/issues/2630
+        file_url = ODataPathParser.encode_method_value(file_url)
+                
+        super(DownloadFileQuery, self).__init__(web, r"getFileByServerRelativePath(decodedurl={0})/$value".format(file_url))
+    
         self.context.before_execute(_construct_download_query)


### PR DESCRIPTION
This commit add support for the following:
- Correctly encoded oData parameter sent to the endpoint.
- Support for # and % in filenames by using a newer 365 endpoint.

Summary:

Current implementation was injecting an URL directly quoted to
the endpoint, instead of encoding as an oData value. This was
solved by using the encode_method_value method. This fixes
issues when the file contains weird characters, like slashes
and single quotes.

The getFileServerByUrl endpoint does not support some characters
in filenames, like # and %. A newer endpoint
(getFileByServerRelativePath) is used instead, which allows to
download files with those characters.