### PR TITLE
Revert ClientObject.get_property() semantics.

### DIFF
--- a/office365/runtime/client_object.py
+++ b/office365/runtime/client_object.py
@@ -79,7 +79,7 @@ class ClientObject(object):
         :param str name: property name
         """
         normalized_name = name[0].lower() + name[1:]
-        return getattr(self, normalized_name, self._properties.get(normalized_name, None))
+        return getattr(self, normalized_name, self._properties.get(name, None))
 
     def set_property(self, name, value, persist_changes=True):
         """Sets property value


### PR DESCRIPTION
In commit 2f486ed4fc775b02224ea38242a9f911cd329a9e a refactoring
of get_property introduced an incompatible change. In that version
a property that was added with set_property() is not retrievable,
as the access to the _properties underlying object uses the
normalized name, instead of the name.

This change adds the previouse behavior (that was right, in my
opinion) in order to not to break backwards compatibility.