### PR TITLE
fix #320 escape XML characters in credentials

### DIFF
--- a/office365/runtime/auth/providers/saml_token_provider.py
+++ b/office365/runtime/auth/providers/saml_token_provider.py
@@ -25,6 +25,7 @@ def xml_escape(s_val):
     s_val = s_val.replace("<", "&lt;")
     s_val = s_val.replace(">", "&gt;")
     s_val = s_val.replace("\"", "&quot;")
+    s_val = s_val.replace("'", "&apos;")
     return s_val
 
 
@@ -159,8 +160,8 @@ class SamlTokenProvider(AuthenticationProvider, office365.logger.LoggerContext):
 
         payload = self._prepare_request_from_template('SAML.xml', {
             'auth_url': self._sts_profile.authorityUrl,
-            'username': self._username,
-            'password': self._password,
+            'username': xml_escape(self._username),
+            'password': xml_escape(self._password),
             'message_id': str(uuid.uuid4()),
             'created': self._sts_profile.created,
             'expires': self._sts_profile.expires,


### PR DESCRIPTION
This change fix bug #320 (Invalid characters in password: Authentification fails with AADSTS90023: Invalid STS request)

# Changes
escape reserved XML characters in username and password before acquire a service token
enhances function xml_escape() to escape single quote character

# Open Question
The method _acquire_service_token_from_adfs() also sends the username and password escaped in a XML structure. I don't make any fix/change here, because I don't have any test code for this method. Should I do this change/fix without any test?