### PR TITLE
retry execution of the query

### DIFF
--- a/office365/runtime/client_runtime_context.py
+++ b/office365/runtime/client_runtime_context.py
@@ -16,7 +16,8 @@ class ClientRuntimeContext(object):
         """
         return self.pending_request().build_single_request(query)
 
-    def execute_query_retry(self, max_retry=5, timeout_secs=5, success_callback=None, failure_callback=None):
+    def execute_query_retry(self, max_retry=5, timeout_secs=5, success_callback=None, failure_callback=None,
+                            exceptions=(ClientRequestException,)):
         """
         Executes the current set of data retrieval queries and method invocations and retries it if needed.
 
@@ -24,6 +25,7 @@ class ClientRuntimeContext(object):
         :param int timeout_secs: Seconds to wait before retrying the request.
         :param (office365.runtime.client_object.ClientObject)-> None success_callback:
         :param (int)-> None failure_callback:
+        :param exceptions: tuple of exceptions that we retry
         """
 
         for retry in range(1, max_retry):
@@ -32,11 +34,11 @@ class ClientRuntimeContext(object):
                 if callable(success_callback):
                     success_callback(self.current_query.return_type)
                 break
-            except ClientRequestException:
+            except exceptions as e:
                 self.add_query(self.current_query, True)
                 sleep(timeout_secs)
                 if callable(failure_callback):
-                    failure_callback(retry)
+                    failure_callback(retry, e)
 
     @abc.abstractmethod
     def pending_request(self):


### PR DESCRIPTION
when uploading large files you may face multiple connection issues from SharePoint side. It would be good if we can retry an execution of the query.
Since we do not have a direct call, then we need to wrap query execution into some function

below I list some possible errors that we faced on our servers when upload:
~~~
11.08.2021 13:34:17 (ERROR) Failed to execute query. Error: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer')) 
11.08.2021 14:16:31 (ERROR) Failed to execute query. Error: ('-1, Microsoft.FileStore.ErrorExceptionTag', 'Error=Value=StoreBusyRetryLater, Tag=0x0305140e', "429 Client Error:  for url: name.tgz')/continueUpload(uploadID='81b56920-2752-4fe7-b2c9-5fe0e0831d4a',fileOffset=15204352000)") 

~~~

such retry function helps to retry with some delay to upload the same chunk (using continue upload)