### PR TITLE
support for inserting proxy and ssl verify data

### DIFF
--- a/office365/runtime/client_request.py
+++ b/office365/runtime/client_request.py
@@ -109,30 +109,35 @@ class ClientRequest(object):
                                          headers=request_options.headers,
                                          data=request_options.data,
                                          auth=request_options.auth,
-                                         verify=request_options.verify)
+                                         verify=request_options.verify,
+                                         proxies=request_options.proxies)
             else:
                 response = requests.post(url=request_options.url,
                                          headers=request_options.headers,
                                          json=request_options.data,
                                          auth=request_options.auth,
-                                         verify=request_options.verify)
+                                         verify=request_options.verify,
+                                         proxies=request_options.proxies)
         elif request_options.method == HttpMethod.Patch:
             response = requests.patch(url=request_options.url,
                                       headers=request_options.headers,
                                       json=request_options.data,
                                       auth=request_options.auth,
-                                      verify=request_options.verify)
+                                      verify=request_options.verify,
+                                      proxies=request_options.proxies)
         elif request_options.method == HttpMethod.Delete:
             response = requests.delete(url=request_options.url,
                                        headers=request_options.headers,
                                        auth=request_options.auth,
-                                       verify=request_options.verify)
+                                       verify=request_options.verify,
+                                       proxies=request_options.proxies)
         elif request_options.method == HttpMethod.Put:
             response = requests.put(url=request_options.url,
                                     data=request_options.data,
                                     headers=request_options.headers,
                                     auth=request_options.auth,
-                                    verify=request_options.verify)
+                                    verify=request_options.verify,
+                                    proxies=request_options.proxies)
         else:
             response = requests.get(url=request_options.url,
                                     headers=request_options.headers,

--- a/office365/runtime/types/EventHandler.py
+++ b/office365/runtime/types/EventHandler.py
@@ -11,6 +11,10 @@ class EventHandler:
         self._listeners.remove(listener)
         return self
 
+    def front_insert(self, listener):
+        self._listeners.insert(0, listener)
+
+
     def notify(self, *args, **kwargs):
         for listener in self._listeners:
             if self._once:

--- a/office365/sharepoint/client_context.py
+++ b/office365/sharepoint/client_context.py
@@ -148,13 +148,16 @@ class ClientContext(ClientRuntimeContext):
         :type request_options: RequestOptions
         """
         if not self._ctx_web_info.is_valid:
-            self._ctx_web_info = self.get_context_web_information()
+            self._ctx_web_info = self.get_context_web_information(request_options=request_options)
         request_options.set_header('X-RequestDigest', self._ctx_web_info.FormDigestValue)
 
-    def get_context_web_information(self):
+    def get_context_web_information(self, request_options=None):
         """Returns an ContextWebInformation object that specifies metadata about the site"""
         request = RequestOptions("contextInfo")
         request.method = HttpMethod.Post
+        if request_options:
+            request.proxies = request_options.proxies
+            request.verify = request_options.verify
         response = self.execute_request_direct(request)
         json = response.json()
         json_format = JsonLightFormat()


### PR DESCRIPTION
Hi,
These are some modifications in order to allow support for proxy and ssl verify.

There are 2 main changes:
- The possibility to insert listeners into `beforeExecute` but in first position, preventing other listeners to make requests before `set_proxy` and `disable_ssl` listeners set appropiate request options.
- To enable access to `request_options`  in `get_context_web_information`  and `execute_request_direct`:

```python
ctx.pending_request().beforeExecute.front_insert(set_proxy)
ctx.pending_request().beforeExecute.front_insert(disable_ssl)
```