### PR TITLE
fix: pytz dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/vgrem/Office365-REST-Python-Client",
-    install_requires=['requests', 'msal'],
+    install_requires=['requests', 'msal', 'pytz'],
     extras_require={
         'NtlmProvider': ["requests_ntlm"]
     },


### PR DESCRIPTION
Some modules inside office currently import the pytz module (which is correctly listed under requirements.txt), but this dependency is NOT mentioned in the setup.py file. This means users pip installing  (and thus also most Docker images) will not have this dependency installed and thus fail. Proposing to simply add pytz to install_requires to fix this problem.