### PR TITLE
fix: sharepoint - setting properties_to_include discards all other previously set query_options

### DIFF
--- a/office365/runtime/queries/read_entity_query.py
+++ b/office365/runtime/queries/read_entity_query.py
@@ -16,8 +16,9 @@ class ReadEntityQuery(ClientQuery):
     @property
     def url(self):
         value = super(ReadEntityQuery, self).url
+        url_query_params = []
         if self._properties_to_include is not None:
-            value += "?" + QueryOptions.build(self.binding_type, self._properties_to_include).to_url()
-        elif not self.binding_type.query_options.is_empty:
-            value += "?" + self.binding_type.query_options.to_url()
-        return value
+            url_query_params += QueryOptions.build(self.binding_type, self._properties_to_include).to_url().split("&")
+        if not self.binding_type.query_options.is_empty:
+            url_query_params += self.binding_type.query_options.to_url().split("&")
+        return value + "?" + "&".join(url_query_params)

--- a/tests/sharepoint/test_listItem.py
+++ b/tests/sharepoint/test_listItem.py
@@ -131,7 +131,21 @@ class TestSharePointListItem(SPTestCase):
         result = self.target_list.items.get().execute_query()
         self.assertEqual(len(result), self.batch_items_count)
 
-    def test_18_delete_multiple_items(self):
+    def test_18_get_multiple_items_with_params(self):
+        # test case for when .load with set properties_to_retrieve
+        # would ignore all other previously set query params (like top(2))
+
+        items = self.target_list.items.top(2)
+        self.client.load(items)
+        self.client.execute_query()
+        
+        items2 = self.target_list.items.top(2)
+        self.client.load(items2, [])
+        self.client.execute_query()
+
+        self.assertEqual(len(items), len(items2))
+
+    def test_19_delete_multiple_items(self):
         items = self.target_list.items.get().execute_query()  # get existing items
         self.assertGreater(len(items), 0)
         for item in items:


### PR DESCRIPTION
take this for example:
https://github.com/vgrem/Office365-REST-Python-Client/blob/31080ae2a9c152dcc9d1b4ce04ff2547876eca79/examples/sharepoint/listitems/attachments/read_attachments.py#L14-L17

if any query_options on ClientObjectCollection would be set (via `items = source_list.items.top(2).order_by("ID desc")` for example), they wouldn't be send as a part of the request anyway - as building query_options when properties_to_include are set (`["ID", "UniqueId", "FileRef", "LinkFilename", "Title", "Attachments"]` in this case) discards all other previously set query_options on ClientObjectCollection object - and builds them based on properties_to_include alone.

https://github.com/vgrem/Office365-REST-Python-Client/blob/31080ae2a9c152dcc9d1b4ce04ff2547876eca79/office365/runtime/queries/read_entity_query.py#L18-L23

I'm not sure if maybe that was the desired behavior here? but it seems really weird in this case. 

anyway, I've included a quick test case for this situation and potential fix - but again, I'm not sure if maybe this behavior wasn't there for some reason and if this fix won't break anything - so, please take a look.

