### PR TITLE
Incompatible attribute type

### DIFF
--- a/tests/calendar/test_calendar.py
+++ b/tests/calendar/test_calendar.py
@@ -9,7 +9,7 @@ class TestCalendar(GraphTestCase):
     """Tests for Calendar"""
 
     cal_name = create_unique_name("Volunteer")
-    target_cal = None  # type: Calendar
+    target_cal = None  # type: Optional[Calendar]
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
**"filename"**: "tests/calendar/test_calendar.py"
**"warning_type"**: "Incompatible attribute type [8]"
**"warning_message"**: " Attribute `target_cal` declared in class `TestCalendar` has type `Calendar` but is used as type `None`."
**"warning_line"**: 12
**"fix"**: Add Optional
