### PR TITLE
fix typo

### DIFF
--- a/office365/sharepoint/principal/principal.py
+++ b/office365/sharepoint/principal/principal.py
@@ -56,7 +56,7 @@ class Principal(BaseEntity):
 
     @property
     def principal_type(self):
-        """Gets the login name of the principal.
+        """Gets the type of the principal.
 
         :rtype: int or None
         """


### PR DESCRIPTION
Fix a typo in the docstring of principal_type function on the Principal class