### PR TITLE
Upload session query method compatible with memoryfs python library

### DIFF
--- a/office365/sharepoint/internal/queries/upload_session.py
+++ b/office365/sharepoint/internal/queries/upload_session.py
@@ -20,18 +20,21 @@ def create_upload_session_query_ex(binding_type, path_or_file, chunk_size, chunk
         return create_upload_session_query(binding_type, f, chunk_size, chunk_uploaded, True, **kwargs)
 
 
-def create_upload_session_query(binding_type, file_object, chunk_size, chunk_uploaded, force_close=False, **kwargs):
+def create_upload_session_query(binding_type, file_object, chunk_size, chunk_uploaded, force_close=False,
+                                file_size=None, file_name=None, **kwargs):
     """
     :type binding_type: office365.sharepoint.files.collection.FileCollection
     :type file_object: typing.IO
     :type chunk_size: int
     :type force_close: bool
     :type chunk_uploaded: (int, *)->None
+    :type file_size: int
+    :type file_name: str
     """
 
     upload_id = str(uuid.uuid4())
-    file_size = os.fstat(file_object.fileno()).st_size
-    file_name = os.path.basename(file_object.name)
+    file_size = file_size if file_size else os.fstat(file_object.fileno()).st_size
+    file_name = file_name if file_name else os.path.basename(file_object.name)
 
     def _read_next():
         return file_object.read(chunk_size)


### PR DESCRIPTION
Python's `memoryfs` library handles reading and writing memory files. The open method from `MemoryFS` class instantiate a `MemoryFile` object.

`MemoryFile` class inherits from `io.RawIOBase` class, thus it can be passed to the `file_object` parameter of the `create_upload_session_query` method.

However, `MemoryFile` does not implements the method `fileno()` (used on the line 34, to get `file_size`), also, the method `os.path.basename()` (used on the line 35 to get `file_name`) cannot parse `MemoryFS` paths.

As a solution to turn `create_upload_session_query` method compatible, I added 2 optional parameters `file_size` and `file_name`, so IO objects (as `MemoryFile` objects) can provide them from the outside of method.

This solution does not break the current usage of the method.