### PR TITLE
Introduce black & fix flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+        args:
+          - --quiet
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args:
+          - --profile=black

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,10 @@
 [metadata]
 description-file = README.md
 
+[isort]
+profile=black
+
+[flake8]
+# F401 - imported but unused
+extend-ignore = E203, E501, W503, F401
+max-line-length = 88


### PR DESCRIPTION
Would you be interested to introduce black for code formatting?

Black fixes the majority of the flake8 issue present in the library today: blanks lines at the end of files, too many blank lines, visual indents, etc

Although Black requires Python 3 to run, it can safely format code for Python 2 and execute as a pre-commit hook.

To implement the Black fixes, you can execute the following:

```bash
pip install pre-commit
pre-commit install
pre-commit run --all
```
You can see an example of changes [here](https://github.com/kellerza/Office365-REST-Python-Client/commit/ce822dab5e2539dab400ad525936e586b048400d) - but this will be a PITA to review, so it's probably best that you do the initial Black run and commit it before we continue
