### PR TITLE
Fix ResourcePath collection

### DIFF
--- a/office365/onedrive/internal/paths/children.py
+++ b/office365/onedrive/internal/paths/children.py
@@ -10,5 +10,8 @@ class ChildrenPath(EntityPath):
     @property
     def collection(self):
         if self._collection is None:
-            self._collection = self.parent.collection
+            if isinstance(self.parent, EntityPath):
+                self._collection = self.parent.collection
+            else:
+                self._collection = self.parent.parent
         return self._collection


### PR DESCRIPTION
Fixes #680

Allows the `enum_folders_and_files` function to work in the example: [list_with_files.py](https://github.com/vgrem/Office365-REST-Python-Client/blob/master/examples/onedrive/folders/list_with_files.py)