### PR TITLE
Conditionally import `ParamSpec` from `typing_extensions`

### DIFF
--- a/office365/runtime/client_object.py
+++ b/office365/runtime/client_object.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -8,9 +9,12 @@ from typing import (
     Generic,
     List,
     Optional,
-    ParamSpec,
     TypeVar,
 )
+if sys.version_info < (3, 10):
+    from typing_extensions import ParamSpec
+else:
+    from typing import ParamSpec
 
 from typing_extensions import Self
 

--- a/office365/runtime/types/event_handler.py
+++ b/office365/runtime/types/event_handler.py
@@ -1,7 +1,12 @@
 import types
 from typing import Callable, Iterator, TypeVar
+import sys
+from typing_extensions import Self
+if sys.version_info < (3, 10):
+    from typing_extensions import ParamSpec
+else:
+    from typing import ParamSpec
 
-from typing_extensions import ParamSpec, Self
 
 P = ParamSpec("P")
 F = TypeVar("F", bound=Callable[..., None])

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/vgrem/Office365-REST-Python-Client",
-    install_requires=["requests", "msal", "pytz", "typing_extensions;python_version<'3.10'"],
+    install_requires=["requests", "msal", "pytz", "typing_extensions;python_version<'3.11'"],
     extras_require={"NtlmProvider": ["requests_ntlm"]},
     tests_require=["pytest", "adal"],
     test_suite="tests",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/vgrem/Office365-REST-Python-Client",
-    install_requires=["requests", "msal", "pytz"],
+    install_requires=["requests", "msal", "pytz", "typing_extensions;python_version<'3.10'"],
     extras_require={"NtlmProvider": ["requests_ntlm"]},
     tests_require=["pytest", "adal"],
     test_suite="tests",


### PR DESCRIPTION
Attempt to fix https://github.com/vgrem/Office365-REST-Python-Client/issues/756 and https://github.com/vgrem/Office365-REST-Python-Client/issues/755