### PR TITLE
Set minimum version of `typing_extensions` to `4.0.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests_ntlm [NTLMAuthentication]
 setuptools==65.5.1
 msal==1.24.1
 pytz==2021.1
+typing_extensions>=4.0.0;python_version<'3.11'

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "requests",
         "msal",
         "pytz",
-        "typing_extensions;python_version<'3.11'",
+        "typing_extensions>=4.0.0;python_version<'3.11'",
     ],
     extras_require={"NtlmProvider": ["requests_ntlm"]},
     tests_require=["pytest", "adal"],


### PR DESCRIPTION
`typing_extensions.Self` was introduced in `4.0.0` so making it as a minimum version required.