### PR TITLE
fix: fix change token entity type name

### DIFF
--- a/office365/sharepoint/changes/token.py
+++ b/office365/sharepoint/changes/token.py
@@ -23,3 +23,8 @@ class ChangeToken(ClientValue):
 
     def __repr__(self):
         return self.StringValue or ""
+
+    @property
+    def entity_type_name(self):
+        return "SP.ChangeToken"
+


### PR DESCRIPTION
This PR fixes the `ChangeToken.entity_type_name` to include the `SP.`. 

Without this, calls of `<list>.get_changes(token)` result in following error message:

```
office365.runtime.client_request_exception.ClientRequestException: ('-1, Microsoft.Data.OData.ODataException', "A type named 'ChangeToken' could not be resolved by the model. When a model is available, each type name must resolve to a valid type.", "400 Client Error: Bad Request for url: <url>
```