### PR TITLE
Require typing_extensions even on Python >= 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,9 @@ requests_ntlm [NTLMAuthentication]
 setuptools==65.5.1
 msal==1.24.1
 pytz==2021.1
-typing_extensions>=4.0.0;python_version<'3.11'
+# The codebase uses "Self" and "Required" available in the typing module
+# since Python 3.11. Therefore, typing_extensions is required as long
+# as Office365-REST-Python-Client supports Python versions < 3.11.
+# On Python versions >= 3.11, typing_extensions re-exports these names
+# from the standard library typing module.
+typing_extensions>=4.0.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "requests",
         "msal",
         "pytz",
-        "typing_extensions>=4.0.0;python_version<'3.11'",
+        "typing_extensions>=4.0.0",
     ],
     extras_require={"NtlmProvider": ["requests_ntlm"]},
     tests_require=["pytest", "adal"],


### PR DESCRIPTION
Fixes #762 

I lack the privileges required to run the tests against any of my employers Sharepoint instances. But since I did not change any Python code, I am still confident this PR does not break anything...