### PR TITLE
Basic fix for "Instance of 'EmailIdentify' has no 'properties' member"

### DIFF
--- a/office365/directory/permissions/email_identity.py
+++ b/office365/directory/permissions/email_identity.py
@@ -1,13 +1,5 @@
-from typing import Optional
-
 from office365.directory.permissions.identity import Identity
 
 
 class EmailIdentity(Identity):
     """Represents the email identity of a user."""
-
-    @property
-    def email(self):
-        # type: () -> Optional[str]
-        """Email address of the user"""
-        return self.properties.get("email", None)

--- a/office365/sharepoint/changes/token.py
+++ b/office365/sharepoint/changes/token.py
@@ -27,4 +27,3 @@ class ChangeToken(ClientValue):
     @property
     def entity_type_name(self):
         return "SP.ChangeToken"
-


### PR DESCRIPTION
This is a basic fix to undo the changes made to `EmailIdentify` (office365/directory/permissions/email_identity.py) in commit https://github.com/vgrem/Office365-REST-Python-Client/commit/4b62b646c4f124227e53d8367099d2627bb99966 that cause the error "Instance of 'EmailIdentity' has no 'properties' member" highlighted by PyLint. If a better solution is to refactor `email_identity` to allow the `email` property to be retained, then feel free to change and/or ignore this Pull request

Secondarily also removes an extra new line to token.py that also caused PyLint complaints