### PR TITLE
fix: do not reuse same instance for recipient

### DIFF
--- a/office365/outlook/mail/recipient.py
+++ b/office365/outlook/mail/recipient.py
@@ -5,10 +5,12 @@ from office365.runtime.client_value import ClientValue
 class Recipient(ClientValue):
     """Represents information about a user in the sending or receiving end of an event, message or group post."""
 
-    def __init__(self, email_address=EmailAddress()):
+    def __init__(self, email_address=None):
         """
         :param EmailAddress email_address: The recipient's email address.
         """
+        if email_address is None:
+            email_address = EmailAddress()
         super(Recipient, self).__init__()
         self.emailAddress = email_address
 


### PR DESCRIPTION
Existing implementation uses same instance for all recipients, causing all sender/recipients to be the same email that is fetched the last.