### PR TITLE
Full SharePoint authentication support with GCC High Environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ pip install Office365-REST-Python-Client
 
 ### Note 
 >
-
 >Alternatively the _latest_ version could be directly installed via GitHub:
 >```
 >pip install git+https://github.com/vgrem/Office365-REST-Python-Client.git
@@ -174,6 +173,20 @@ The list of examples:
   -  [delete a list item](examples/sharepoint/listitems/delete.py) 
   
 Refer [examples section](examples/sharepoint) for another scenarios
+
+### Support for non-standard SharePoint Online Environments
+
+  Support for non-standard SharePoint Environments is currently being implemented. Currently supported:
+  - GCC High
+
+  To enable authentication to GCC High endpoints, add the `environment='GCCH'` parameter when calling the 
+  `ClientContext class` with `.with_user_credentials`, `.with_client_credentials`, or `.with_credentials`
+
+   Example:
+   ```python
+   client_credentials = ClientCredential('{client_id}','{client_secret}')
+   ctx = ClientContext('{url}').with_credentials(client_credentials, environment='GCCH')
+   ```
 
 # Working with Outlook API
 

--- a/office365/runtime/auth/authentication_context.py
+++ b/office365/runtime/auth/authentication_context.py
@@ -173,8 +173,9 @@ class AuthenticationContext(object):
         :param UserCredential or ClientCredential credentials:
         """
         if isinstance(credentials, ClientCredential):
+            environment = kwargs.get("environment")
             provider = ACSTokenProvider(
-                self.url, credentials.clientId, credentials.clientSecret
+                self.url, credentials.clientId, credentials.clientSecret, environment
             )
         elif isinstance(credentials, UserCredential):
             allow_ntlm = kwargs.get("allow_ntlm", False)

--- a/office365/runtime/auth/providers/acs_token_provider.py
+++ b/office365/runtime/auth/providers/acs_token_provider.py
@@ -10,7 +10,7 @@ from office365.runtime.http.request_options import RequestOptions
 
 
 class ACSTokenProvider(AuthenticationProvider, office365.logger.LoggerContext):
-    def __init__(self, url, client_id, client_secret, environment):
+    def __init__(self, url, client_id, client_secret, environment='commercial'):
         """
         Provider to acquire the access token from a Microsoft Azure Access Control Service (ACS)
 

--- a/office365/sharepoint/client_context.py
+++ b/office365/sharepoint/client_context.py
@@ -81,7 +81,7 @@ class ClientContext(ClientRuntimeContext):
         thumbprint,
         cert_path=None,
         private_key=None,
-        scopes=None,
+        scopes=None
     ):
         # type: (str, str, str, Optional[str], Optional[str], Optional[List[str]]) -> Self
         """
@@ -93,7 +93,6 @@ class ClientContext(ClientRuntimeContext):
         :param str thumbprint: Hex encoded thumbprint of the certificate.
         :param str client_id: The OAuth client id of the calling application.
         :param list[str] or None scopes:  Scopes requested to access a protected API (a resource)
-
         """
         self.authentication_context.with_client_certificate(
             tenant, client_id, thumbprint, cert_path, private_key, scopes
@@ -139,15 +138,15 @@ class ClientContext(ClientRuntimeContext):
     def with_user_credentials(
         self, username, password, allow_ntlm=False, browser_mode=False, environment='commercial'
     ):
-        # type: (str, str, bool, bool, str) -> Self
+        # type: (str, str, bool, bool, Optional[str]) -> Self
         """
         Initializes a client to acquire a token via user credentials.
         :param str username: Typically, a UPN in the form of an email address
         :param str password: The password
         :param bool allow_ntlm: Flag indicates whether NTLM scheme is enabled. Disabled by default
         :param bool browser_mode:
-        :param str environment: The Office 365 Cloud Environment endpoint used for authentication.
-        By default, this will be set to commercial ('commercial', 'GCCH')
+        :param str environment: The Office 365 Cloud Environment endpoint used for authentication
+            defaults to 'commercial'.
         """
         self.authentication_context.with_credentials(
             UserCredential(username, password),
@@ -157,8 +156,8 @@ class ClientContext(ClientRuntimeContext):
         )
         return self
 
-    def with_client_credentials(self, client_id, client_secret):
-        # type: (str, str) -> Self
+    def with_client_credentials(self, client_id, client_secret, environment='commercial'):
+        # type: (str, str, Optional[str]) -> Self
         """
         Initializes a client to acquire a token via client credentials (SharePoint App-Only)
 
@@ -167,19 +166,24 @@ class ClientContext(ClientRuntimeContext):
 
         :param str client_id: The OAuth client id of the calling application
         :param str client_secret: Secret string that the application uses to prove its identity when requesting a token
+        :param str environment: The Office 365 Cloud Environment endpoint used for authentication
+            defaults to 'commercial'.
         """
         self.authentication_context.with_credentials(
-            ClientCredential(client_id, client_secret)
+            ClientCredential(client_id, client_secret),
+            environment=environment
         )
         return self
 
-    def with_credentials(self, credentials):
-        # type: (UserCredential|ClientCredential) -> Self
+    def with_credentials(self, credentials, environment='commercial'):
+        # type: (UserCredential|ClientCredential, Optional[str]) -> Self
         """
         Initializes a client to acquire a token via user or client credentials
         :type credentials: UserCredential or ClientCredential
+        :param str environment: The Office 365 Cloud Environment endpoint used for authentication
+            defaults to 'commercial'.
         """
-        self.authentication_context.with_credentials(credentials)
+        self.authentication_context.with_credentials(credentials, environment=environment)
         return self
 
     def execute_batch(self, items_per_batch=100, success_callback=None):


### PR DESCRIPTION
This will add full authentication support for **SharePoint** GCC High environments. This only affects non-MSAL utilizing functions within the `ClientContext class` as MSAL naively supports cross-cloud authentication attempts. Also updated `README` to reflect support.