### PR TITLE
Fixes issue of __str__ raising exception when DecodeUrl is None

### DIFF
--- a/office365/sharepoint/types/resource_path.py
+++ b/office365/sharepoint/types/resource_path.py
@@ -44,7 +44,7 @@ class ResourcePath(ClientValue):
         return "SP.ResourcePath"
 
     def __str__(self):
-        return self.DecodedUrl
+        return self.DecodedUrl or ""
 
     def __repr__(self):
         return self.DecodedUrl or self.entity_type_name


### PR DESCRIPTION
If DecodeUrl attribute is None then __str__ method will raise '''TypeError: __str__ returned non-string (type NoneType)'''. To avoid it we can ensure that __str__ method returns string type of object.