### PR TITLE
better type hint for ClientContext constructor

### DIFF
--- a/office365/sharepoint/client_context.py
+++ b/office365/sharepoint/client_context.py
@@ -42,7 +42,7 @@ class ClientContext(ClientRuntimeContext):
     """SharePoint client context (SharePoint v1 API)"""
 
     def __init__(self, base_url, auth_context=None):
-        # type: (str, AuthenticationContext) -> None
+        # type: (str, AuthenticationContext | None) -> None
         """
         Instantiates a SharePoint client context
 


### PR DESCRIPTION
PyLance complained about auth_context being None