### PR TITLE
add exceptions parameter to client_object.execute_query_retry to mirror client_runtime_context.execute_query_retry

### DIFF
--- a/office365/runtime/client_object.py
+++ b/office365/runtime/client_object.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, List, Optional, TypeVa
 from requests import Response
 from typing_extensions import Self
 
+from office365.runtime.client_request_exception import ClientRequestException
 from office365.runtime.client_runtime_context import ClientRuntimeContext
 from office365.runtime.client_value import ClientValue
 from office365.runtime.http.request_options import RequestOptions
@@ -55,7 +56,12 @@ class ClientObject(Generic[T]):
         return self
 
     def execute_query_retry(
-        self, max_retry=5, timeout_secs=5, success_callback=None, failure_callback=None
+        self,
+        max_retry=5,
+        timeout_secs=5,
+        success_callback=None,
+        failure_callback=None,
+        exceptions=(ClientRequestException,)
     ):
         """
         Executes the current set of data retrieval queries and method invocations and retries it if needed.
@@ -66,12 +72,14 @@ class ClientObject(Generic[T]):
             if the request executes successfully.
         :param (int, requests.exceptions.RequestException)-> None failure_callback: A callback to call if the request
             fails to execute
+        :param exceptions: tuple of exceptions that we retry
         """
         self.context.execute_query_retry(
             max_retry=max_retry,
             timeout_secs=timeout_secs,
             success_callback=success_callback,
             failure_callback=failure_callback,
+            exceptions=exceptions
         )
         return self
 


### PR DESCRIPTION
`client_runtime_context.execute_query_retry` takes an `exceptions` parameter that controls what exceptions would be retried. `client_object.execute_query_retry` does not have that parameter, despite simply wrapping `client_runtime_context.execute_query_retry`.
 
As far as I can tell, this was simply an oversight when the parameter was added to the method in client_runtime_context, and I see no reason why client_object should not also have that parameter.