### PR TITLE
add exceptions parameter to client_result.execute_query_retry to mirror client_runtime_context.execute_query_retry

### DIFF
--- a/office365/runtime/client_object.py
+++ b/office365/runtime/client_object.py
@@ -61,7 +61,7 @@ class ClientObject(Generic[T]):
         timeout_secs=5,
         success_callback=None,
         failure_callback=None,
-        exceptions=(ClientRequestException,)
+        exceptions=(ClientRequestException,),
     ):
         """
         Executes the current set of data retrieval queries and method invocations and retries it if needed.
@@ -79,7 +79,7 @@ class ClientObject(Generic[T]):
             timeout_secs=timeout_secs,
             success_callback=success_callback,
             failure_callback=failure_callback,
-            exceptions=exceptions
+            exceptions=exceptions,
         )
         return self
 

--- a/office365/runtime/client_result.py
+++ b/office365/runtime/client_result.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Callable, Generic, Optional, TypeVar
 
 from typing_extensions import Self
 
+from office365.runtime.client_request_exception import ClientRequestException
 from office365.runtime.http.request_options import RequestOptions
 
 if TYPE_CHECKING:
@@ -54,13 +55,29 @@ class ClientResult(Generic[T]):
         return self
 
     def execute_query_retry(
-        self, max_retry=5, timeout_secs=5, success_callback=None, failure_callback=None
+        self,
+        max_retry=5,
+        timeout_secs=5,
+        success_callback=None,
+        failure_callback=None,
+        exceptions=(ClientRequestException,),
     ):
-        """Executes the current set of data retrieval queries and method invocations and retries it if needed."""
+        """
+        Executes the current set of data retrieval queries and method invocations and retries it if needed.
+
+        :param int max_retry: Number of times to retry the request
+        :param int timeout_secs: Seconds to wait before retrying the request.
+        :param (office365.runtime.client_object.ClientObject)-> None success_callback: A callback to call
+            if the request executes successfully.
+        :param (int, requests.exceptions.RequestException)-> None failure_callback: A callback to call if the request
+            fails to execute
+        :param exceptions: tuple of exceptions that we retry
+        """
         self._context.execute_query_retry(
             max_retry=max_retry,
             timeout_secs=timeout_secs,
             success_callback=success_callback,
             failure_callback=failure_callback,
+            exceptions=exceptions,
         )
         return self


### PR DESCRIPTION
Same idea as my [previous pull request](https://github.com/vgrem/Office365-REST-Python-Client/pull/890), but this time regarding `ClientResult` + some code formatting fixes

I didn't find any other wrappers of `ClientContext.execute_query_retry`, so this should be the last one

