### PR TITLE
Adding outlook mail messages update functionality, which was not there 

### DIFF
--- a/office365/outlook/mail/messages/message.py
+++ b/office365/outlook/mail/messages/message.py
@@ -164,10 +164,7 @@ class Message(OutlookItem):
 
     def reply_all(self):
         """Reply to all recipients of a message. The message is then saved in the Sent Items folder."""
-        return_type = Message(self.context)
-        qry = ServiceOperationQuery(
-            self, "replyAll", None, None, return_type
-        )
+        qry = ServiceOperationQuery(self, "replyAll")
         self.context.add_query(qry)
         return self
 
@@ -191,7 +188,10 @@ class Message(OutlookItem):
         You can then update the draft to add reply content to the body or change other message properties, or,
         simply send the draft.
         """
-        qry = ServiceOperationQuery(self, "createReplyAll")
+        return_type = Message(self.context)
+        qry = ServiceOperationQuery(
+            self, "createReplyAll", None, None, return_type
+        )
         self.context.add_query(qry)
         return self
 

--- a/office365/outlook/mail/messages/message.py
+++ b/office365/outlook/mail/messages/message.py
@@ -136,7 +136,7 @@ class Message(OutlookItem):
 
 
             
-        qry = ServiceOperationQuery(self, None, payload)
+        qry = ServiceOperationQuery(self, None, None, payload)
         self.context.add_query(qry).before_execute(_construct_request)
         
         return self

--- a/office365/outlook/mail/messages/message.py
+++ b/office365/outlook/mail/messages/message.py
@@ -19,6 +19,7 @@ from office365.outlook.mail.messages.internet_header import InternetMessageHeade
 from office365.outlook.mail.recipient import Recipient
 from office365.runtime.client_result import ClientResult
 from office365.runtime.client_value_collection import ClientValueCollection
+from office365.runtime.http.http_method import HttpMethod
 from office365.runtime.paths.resource_path import ResourcePath
 from office365.runtime.queries.function import FunctionQuery
 from office365.runtime.queries.service_operation import ServiceOperationQuery
@@ -122,6 +123,22 @@ class Message(OutlookItem):
             self.attachments.add_file(
                 os.path.basename(file_object.name), content.decode("utf-8")
             )
+        return self
+    
+    def update(self, payload):
+        """
+        Update the properties of a message. Only the properties that are set in the request body will be updated.
+
+        :param dict payload: A JSON object that contains the properties and values for the message.
+        """
+        def _construct_request(request):
+            request.method = HttpMethod.Patch
+
+
+            
+        qry = ServiceOperationQuery(self, None, payload)
+        self.context.add_query(qry).before_execute(_construct_request)
+        
         return self
 
     def send(self):

--- a/office365/outlook/mail/messages/message.py
+++ b/office365/outlook/mail/messages/message.py
@@ -190,7 +190,7 @@ class Message(OutlookItem):
         """
         return_type = Message(self.context)
         qry = ServiceOperationQuery(
-            self, "createReplyAll", None, None, return_type
+            self, "createReplyAll", None, None, None, return_type
         )
         self.context.add_query(qry)
         return self

--- a/office365/outlook/mail/messages/message.py
+++ b/office365/outlook/mail/messages/message.py
@@ -188,10 +188,7 @@ class Message(OutlookItem):
         You can then update the draft to add reply content to the body or change other message properties, or,
         simply send the draft.
         """
-        return_type = Message(self.context)
-        qry = ServiceOperationQuery(
-            self, "createReplyAll", None, None, None, return_type
-        )
+        qry = ServiceOperationQuery(self, "createReplyAll")
         self.context.add_query(qry)
         return self
 

--- a/office365/subscriptions/collection.py
+++ b/office365/subscriptions/collection.py
@@ -17,7 +17,9 @@ class SubscriptionCollection(EntityCollection[Subscription]):
         expiration,
         client_state=None,
         latest_supported_tls_version=None,
-        include_resource_data=False,
+        include_resource_data=None,
+        encryption_certificate=None,
+        encryption_certificate_id=None,
     ):
         """
         Subscribes a listener application to receive change notifications when the requested type of changes occur
@@ -35,6 +37,16 @@ class SubscriptionCollection(EntityCollection[Subscription]):
         :param str latest_supported_tls_version:  Specifies the latest version of Transport Layer Security (TLS) that
             the notification endpoint, specified by notificationUrl, supports.
             The possible values are: v1_0, v1_1, v1_2, v1_3.
+        :param bool include_resource_data: Indicates whether the resource data for the resource that generated the
+            change notification should be included in the payload of the notification.
+        :param str encryption_certificate: Specifies the public key certificate which contains only the public key 
+            that Microsoft Graph uses to encrypt the resource data it returns to your app. For security, Microsoft 
+            Graph encrypts the resource data returned in a rich notification. You must provide a public encryption 
+            key as part of creating the subscription. 
+        :param str encryption_certificate_id: Specifies the identifier of the certificate used to encrypt the content
+            of the change notification. Use this ID to match in each change notification, which certificate to use 
+            for decryption.
+        :return: Subscription
         """
         return_type = Subscription(self.context)
         self.add_child(return_type)
@@ -46,6 +58,8 @@ class SubscriptionCollection(EntityCollection[Subscription]):
             "clientState": client_state,
             "latestSupportedTlsVersion": latest_supported_tls_version,
             "includeResourceData": include_resource_data,
+            "encryptionCertificate": encryption_certificate,
+            "encryptionCertificateId": encryption_certificate_id,
         }
         qry = CreateEntityQuery(self, payload, return_type)
         self.context.add_query(qry)


### PR DESCRIPTION
This pull request allows to update a message in outlook based on this documentation:
https://learn.microsoft.com/en-us/graph/api/message-update?view=graph-rest-1.0&tabs=http