### PR TITLE
Added Reply To and HTML ItemBody Type support in send_mail functionality

### DIFF
--- a/office365/directory/users/user.py
+++ b/office365/directory/users/user.py
@@ -274,8 +274,9 @@ class User(DirectoryObject):
         bcc_recipients=None,
         reply_to = None,
         save_to_sent_items=False,
+        body_type="Text",
     ):
-        # type: (str, str|ItemBody, List[str], List[str], List[str], bool) -> Message
+        # type: (str, str|ItemBody, List[str], List[str]|None, List[str]|None, List[str]|None, bool, str) -> Message
         """Send a new message on the fly
 
         :param str subject: The subject of the message.
@@ -286,10 +287,11 @@ class User(DirectoryObject):
         :param list[str] reply_to: The Reply-To: : recipients for the reply to the message.
         :param bool save_to_sent_items: Indicates whether to save the message in Sent Items. Specify it only if
             the parameter is false; default is true
+        :param str body_type: The type of the message body. It can be "HTML" or "Text". Default is "Text".
         """
         return_type = Message(self.context)
         return_type.subject = subject
-        return_type.body = body
+        return_type.body = (body, body_type)
         [
             return_type.to_recipients.add(Recipient.from_email(email))
             for email in to_recipients

--- a/office365/directory/users/user.py
+++ b/office365/directory/users/user.py
@@ -272,6 +272,7 @@ class User(DirectoryObject):
         to_recipients,
         cc_recipients=None,
         bcc_recipients=None,
+        reply_to = None,
         save_to_sent_items=False,
     ):
         # type: (str, str|ItemBody, List[str], List[str], List[str], bool) -> Message
@@ -282,6 +283,7 @@ class User(DirectoryObject):
         :param list[str] to_recipients: The To: recipients for the message.
         :param list[str] cc_recipients: The CC: recipients for the message.
         :param list[str] bcc_recipients: The BCC: recipients for the message.
+        :param list[str] reply_to: The Reply-To: : recipients for the reply to the message.
         :param bool save_to_sent_items: Indicates whether to save the message in Sent Items. Specify it only if
             the parameter is false; default is true
         """
@@ -301,6 +303,11 @@ class User(DirectoryObject):
             [
                 return_type.cc_recipients.add(Recipient.from_email(email))
                 for email in cc_recipients
+            ]
+        if reply_to is not None:
+            [
+                return_type.reply_to.add(Recipient.from_email(email))
+                for email in reply_to
             ]
 
         payload = {"message": return_type, "saveToSentItems": save_to_sent_items}

--- a/office365/outlook/mail/messages/message.py
+++ b/office365/outlook/mail/messages/message.py
@@ -408,6 +408,14 @@ class Message(OutlookItem):
         )
 
     @property
+    def reply_to(self):
+        """The replyTo: recipients for the reply to the message."""
+        self._persist_changes("replyTo")
+        return self.properties.setdefault(
+            "replyTo", ClientValueCollection(Recipient)
+        )
+
+    @property
     def sender(self):
         """The account that is actually used to generate the message. In most cases, this value is the same as the
         from property. You can set this property to a different value when sending a message from a shared mailbox,

--- a/office365/outlook/mail/messages/message.py
+++ b/office365/outlook/mail/messages/message.py
@@ -258,11 +258,22 @@ class Message(OutlookItem):
 
     @body.setter
     def body(self, value):
-        # type: (str|ItemBody) -> None
+        # type: (str|ItemBody|tuple) -> None
         """Sets the body of the message. It can be in HTML or text format."""
-        if not isinstance(value, ItemBody):
-            value = ItemBody(value)
-        self.set_property("body", value)
+        content_type = "Text"  # Default content type
+        if isinstance(value, tuple):
+            if len(value) != 2:
+                raise ValueError("value must be a tuple of (content, content_type)")
+            content, content_type = value
+        else:
+            content = value
+        if isinstance(content, ItemBody):
+            self.set_property("body", content)
+            return
+        if content_type.lower() not in ["text", "html"]:
+            raise ValueError("content_type must be either 'Text' or 'HTML'")
+        item_body = ItemBody(content=content, content_type=content_type)
+        self.set_property("body", item_body)
 
     @property
     def body_preview(self):


### PR DESCRIPTION
Tested on the local system as well. Backward compatibility kept in mind for implementation.

Issue:
Current send_mail function doesn't have the functionality of setting reply_to address. Alongwith it, for setting HTML body type, you need to create an ItemBody type first with HTML content_type and then send that to send_mail. New implementation will ease things out for users.