### PR TITLE
Add timeout support to HTTP requests

### DIFF
--- a/office365/runtime/client_request.py
+++ b/office365/runtime/client_request.py
@@ -53,6 +53,7 @@ class ClientRequest(object):
                     auth=request.auth,
                     verify=request.verify,
                     proxies=request.proxies,
+                    timeout=request.timeout
                 )
             else:
                 response = requests.post(
@@ -62,6 +63,7 @@ class ClientRequest(object):
                     auth=request.auth,
                     verify=request.verify,
                     proxies=request.proxies,
+                    timeout=request.timeout
                 )
         elif request.method == HttpMethod.Patch:
             response = requests.patch(
@@ -71,6 +73,7 @@ class ClientRequest(object):
                 auth=request.auth,
                 verify=request.verify,
                 proxies=request.proxies,
+                timeout=request.timeout
             )
         elif request.method == HttpMethod.Delete:
             response = requests.delete(
@@ -79,6 +82,7 @@ class ClientRequest(object):
                 auth=request.auth,
                 verify=request.verify,
                 proxies=request.proxies,
+                timeout=request.timeout
             )
         elif request.method == HttpMethod.Put:
             response = requests.put(
@@ -88,6 +92,7 @@ class ClientRequest(object):
                 auth=request.auth,
                 verify=request.verify,
                 proxies=request.proxies,
+                timeout=request.timeout
             )
         else:
             response = requests.get(
@@ -97,6 +102,7 @@ class ClientRequest(object):
                 verify=request.verify,
                 stream=request.stream,
                 proxies=request.proxies,
+                timeout=request.timeout
             )
         response.raise_for_status()
         return response

--- a/office365/runtime/http/request_options.py
+++ b/office365/runtime/http/request_options.py
@@ -20,6 +20,7 @@ class RequestOptions(object):
         self.verify = True
         self.stream = False
         self.proxies = None
+        self.timeout = None
 
     @property
     def is_file(self):


### PR DESCRIPTION
Add a timeout parameter to RequestOptions and propagate it to all HTTP method calls in ClientRequest, allowing developers to configure request timeouts.

By default, requests have no timeout, which can cause them to hang indefinitely. This change gives developers the ability to define a maximum duration for requests, helping to avoid such issues.