### PR TITLE
fix: swap High/Low in BasePermissions.set() and has()

### DIFF
--- a/office365/sharepoint/permissions/base_permissions.py
+++ b/office365/sharepoint/permissions/base_permissions.py
@@ -42,9 +42,9 @@ class BasePermissions(ClientValue):
             bit_pos = perm.value - 1
             mask = 1 << (bit_pos % self._BITS_PER_INT)
             if bit_pos < self._BITS_PER_INT:
-                self.High |= mask
-            elif self._BITS_PER_INT <= bit_pos < self._MAX_BITS:
                 self.Low |= mask
+            elif self._BITS_PER_INT <= bit_pos < self._MAX_BITS:
+                self.High |= mask
 
     def has(self, perm: Union[PermissionKind, int]) -> bool:
         """Checks if permission is set with support for both enum and integer values."""
@@ -58,7 +58,7 @@ class BasePermissions(ClientValue):
         if not 0 <= bit_pos < self._MAX_BITS:
             return False
         mask = 1 << (bit_pos % self._BITS_PER_INT)
-        return bool(self.High & mask) if bit_pos < self._BITS_PER_INT else bool(self.Low & mask)
+        return bool(self.Low & mask) if bit_pos < self._BITS_PER_INT else bool(self.High & mask)
 
     def clear_all(self):
         """Clears all permissions for the current instance."""


### PR DESCRIPTION
## Summary

`BasePermissions.set()` and `has()` had `High` and `Low` swapped internally:

- Bits 0-31 (lower 32 bits) were stored in `self.High`
- Bits 32-63 (upper 32 bits) were stored in `self.Low`

This caused `to_json()` to serialize values into the wrong API fields — sending Low bits as `High` and High bits as `Low`.

## Fix

Swapped the field assignments in `set()` and field checks in `has()`:

```diff
  if bit_pos < self._BITS_PER_INT:
-    self.High |= mask
     self.Low |= mask
+    self.High |= mask

- return bool(self.High & mask) if bit_pos < self._BITS_PER_INT else bool(self.Low & mask)
+ return bool(self.Low & mask) if bit_pos < self._BITS_PER_INT else bool(self.High & mask)
```

`to_json()` and `set_property()` are already correct — they just received swapped values.

## Example

Before fix:
| Permission | Bit | Stored in | JSON output |
|---|---|---|---|
| ViewListItems (bit 0) | Low | self.High | `{"Low": 0, "High": 1}` |
| ManageWeb (bit 35) | High | self.Low | `{"Low": 8, "High": 0}` |

After fix:
| Permission | Bit | Stored in | JSON output |
|---|---|---|---|
| ViewListItems (bit 0) | Low | self.Low | `{"Low": 1, "High": 0}` |
| ManageWeb (bit 35) | High | self.High | `{"Low": 0, "High": 8}` |

Fixes #959