### PR TITLE
fix: handle JSON file download from OneDrive /content endpoint

### DIFF
--- a/office365/onedrive/driveitems/driveItem.py
+++ b/office365/onedrive/driveitems/driveItem.py
@@ -427,7 +427,7 @@ class DriveItem(BaseItem):
         action_name = "content"
         if format_name is not None:
             action_name = action_name + rf"?format={format_name}"
-        qry = FunctionQuery(self, action_name, None, return_type)
+        qry = FunctionQuery(self, action_name, None, return_type, return_raw_content=True)
         self.context.add_query(qry)
         return return_type
 

--- a/office365/runtime/odata/request.py
+++ b/office365/runtime/odata/request.py
@@ -79,7 +79,7 @@ class ODataRequest(ClientRequest):
 
         content_type = response.headers.get("Content-Type", "").lower().split(";")[0]
 
-        if content_type != "application/json" or self._is_content_download(query):
+        if content_type != "application/json" or self._is_raw_content_query(query):
             if isinstance(return_type, ClientResult):
                 return_type.set_property("__value", response.content)
         else:
@@ -90,9 +90,9 @@ class ODataRequest(ClientRequest):
             self.map_json(response.json(), return_type, json_format)
 
     @staticmethod
-    def _is_content_download(query: ClientQuery) -> bool:
-        """Check if the query is a raw content download (file content, not OData metadata)."""
-        return bool(getattr(query, "return_raw_content", False))
+    def _is_raw_content_query(query: ClientQuery) -> bool:
+        """Check if the query represents a raw content retrieval (e.g. file download)."""
+        return isinstance(query, FunctionQuery) and query.return_raw_content
 
     def map_json(
         self,

--- a/office365/runtime/odata/request.py
+++ b/office365/runtime/odata/request.py
@@ -92,10 +92,7 @@ class ODataRequest(ClientRequest):
     @staticmethod
     def _is_content_download(query: ClientQuery) -> bool:
         """Check if the query is a raw content download (file content, not OData metadata)."""
-        if isinstance(query, FunctionQuery):
-            name = query.name
-            return name in ("content", "$value")
-        return False
+        return bool(getattr(query, "return_raw_content", False))
 
     def map_json(
         self,

--- a/office365/runtime/odata/request.py
+++ b/office365/runtime/odata/request.py
@@ -77,7 +77,9 @@ class ODataRequest(ClientRequest):
         if isinstance(return_type, ClientObject):
             return_type.clear_state()
 
-        if response.headers.get("Content-Type", "").lower().split(";")[0] != "application/json":
+        content_type = response.headers.get("Content-Type", "").lower().split(";")[0]
+
+        if content_type != "application/json" or self._is_content_download(query):
             if isinstance(return_type, ClientResult):
                 return_type.set_property("__value", response.content)
         else:
@@ -86,6 +88,14 @@ class ODataRequest(ClientRequest):
                     json_format.function = query.name
 
             self.map_json(response.json(), return_type, json_format)
+
+    @staticmethod
+    def _is_content_download(query: ClientQuery) -> bool:
+        """Check if the query is a raw content download (file content, not OData metadata)."""
+        if isinstance(query, FunctionQuery):
+            name = query.name
+            return name in ("content", "$value")
+        return False
 
     def map_json(
         self,

--- a/office365/runtime/queries/function.py
+++ b/office365/runtime/queries/function.py
@@ -15,6 +15,7 @@ class FunctionQuery(ClientQuery[ReturnT]):
         method_name: str | None = None,
         method_params: list | dict | ClientValue | None = None,
         return_type: ReturnT | None = None,
+        return_raw_content: bool = False,
     ) -> None:
         """Initialize a function query.
 
@@ -23,9 +24,17 @@ class FunctionQuery(ClientQuery[ReturnT]):
             method_name: The name of the method to call
             method_params: Parameters for the method call
             return_type: The expected return type
+            return_raw_content: When True, the response body is treated as raw content
+                (e.g. file download) rather than parsed as OData JSON.
         """
         super().__init__(binding_type.context, binding_type, None, None, return_type)
         self._path = ServiceOperationPath(method_name or "", method_params, binding_type.resource_path)
+        self._return_raw_content = return_raw_content
+
+    @property
+    def return_raw_content(self) -> bool:
+        """Whether the response should be treated as raw content, not OData JSON."""
+        return self._return_raw_content
 
     def __repr__(self) -> str:
         return f"FunctionQuery(name={self.path.name})"

--- a/office365/sharepoint/files/file.py
+++ b/office365/sharepoint/files/file.py
@@ -140,7 +140,7 @@ class File(AbstractFile):
     def get_content(self) -> ClientResult[bytes]:
         """Downloads a file content"""
         return_type = ClientResult(self.context, bytes())
-        qry = FunctionQuery(self, "$value", return_type=return_type)
+        qry = FunctionQuery(self, "$value", return_type=return_type, return_raw_content=True)
         self.context.add_query(qry)
         return return_type
 


### PR DESCRIPTION
## Description

Fixes downloading `.json` files from OneDrive via `DriveItem.download()`.

### Problem

The OData response processor in `process_response()` relies solely on the `Content-Type` header to decide whether to parse the body as OData JSON or return raw bytes. When downloading a `.json` file from OneDrive, the Graph `/content` endpoint returns `application/json`, causing the client to parse the *file contents* as an OData response instead of returning raw bytes.

The SharePoint `$value` endpoint doesnt have this issue because it returns `application/octet-stream`.

### Fix

Added `_is_content_download()` static method that checks if the query is a `FunctionQuery` named `"content"` (OneDrive) or `"$value"` (SharePoint) — these always represent raw file content. When true, the response body is returned as raw bytes regardless of Content-Type.

### Changes

- `office365/runtime/odata/request.py`: 11 insertions, 1 deletion

Fixes #944, #598

### Testing
- [ ] OneDrive download of .json files
- [ ] OneDrive download of .txt, .csv, .bin files (should continue working)
- [ ] SharePoint download via `$value` (should continue working)